### PR TITLE
Minor changes to file upload

### DIFF
--- a/install_xqueue.sh
+++ b/install_xqueue.sh
@@ -7,11 +7,12 @@
 apt-get update
 apt-get install nginx gunicorn rabbitmq-server
 apt-get install python-pip python-mysqldb
-pip install django requests pika boto
+pip install django requests pika boto path.py
 
 # Set up nginx proxy, then restart
 cp nginx.conf /etc/nginx/nginx.conf
 /etc/init.d/nginx restart
+mkdir ../log
 
 # Start RabbitMQ
 rabbitmqctl start_app

--- a/queue/lms_interface.py
+++ b/queue/lms_interface.py
@@ -35,7 +35,7 @@ def submit(request):
                 s3_keys = dict() # For internal Xqueue use
                 s3_urls = dict() # For external grader use
                 for filename in request.FILES.keys():
-                    s3_key = make_hashkey(xqueue_header+filename)
+                    s3_key = make_hashkey(xqueue_header + filename)
                     s3_url = _upload_to_s3(request.FILES[filename], s3_key, queue_name)
                     s3_keys.update({filename: s3_key})
                     s3_urls.update({filename: s3_url})

--- a/queue/lms_interface.py
+++ b/queue/lms_interface.py
@@ -36,7 +36,7 @@ def submit(request):
                 s3_urls = dict() # For external grader use
                 for filename in request.FILES.keys():
                     s3_key = make_hashkey(xqueue_header+filename)
-                    s3_url = _upload_to_s3(request.FILES[filename],s3_key) # TODO: Sanity check on file (e.g. size)
+                    s3_url = _upload_to_s3(request.FILES[filename], s3_key, queue_name)
                     s3_keys.update({filename: s3_key})
                     s3_urls.update({filename: s3_url})
 
@@ -92,7 +92,7 @@ def _is_valid_request(xrequest):
     return (True, queue_name, header, body)
     
 
-def _upload_to_s3(file_to_upload, s3_keyname):
+def _upload_to_s3(file_to_upload, keyname, bucketname):
     '''
     Upload file to S3 using provided keyname.
 
@@ -100,13 +100,13 @@ def _upload_to_s3(file_to_upload, s3_keyname):
         public_url: URL to access uploaded file 
     '''
     conn = S3Connection(settings.AWS_ACCESS_KEY_ID, settings.AWS_SECRET_ACCESS_KEY)
-    bucketname = settings.AWS_ACCESS_KEY_ID+'bucket' # TODO: Bucket name(s)
+    bucketname = settings.AWS_ACCESS_KEY_ID + '_' + bucketname
     bucket = conn.create_bucket(bucketname.lower())
 
     k = Key(bucket)
-    k.key = s3_keyname
+    k.key = keyname
     k.set_metadata('filename',file_to_upload.name)
     k.set_contents_from_file(file_to_upload)
-    public_url = k.generate_url(60*60*24) # Timeout in seconds. TODO: Make permanent (until explicit cleanup)
+    public_url = k.generate_url(60*60*24*365) # URL timeout in seconds.
     
     return public_url

--- a/queue/util.py
+++ b/queue/util.py
@@ -13,8 +13,6 @@ def get_request_ip(request):
     Retrieve the IP origin of a Django request
     '''
     ip = request.META.get('HTTP_X_REAL_IP','') # nginx reverse proxy
-    print 'HTTP_X_REAL_IP: %s' % ip
     if not ip:
         ip = request.META.get('REMOTE_ADDR','None')
-        print 'REMOTE_ADDR: %s' % ip
     return ip


### PR DESCRIPTION
Minor changes to queue file uploads (original already handled multiple files):
- Bucket name == AWS_ACCESS_KEY + queue_name
- Remove debugging print from util
- Public URL will exist for 1 year
