### PR TITLE
Kimth/queue dos pull

### DIFF
--- a/queue/consumer.py
+++ b/queue/consumer.py
@@ -21,6 +21,17 @@ def clean_up_submission(submission):
     return
 
 
+def get_single_unretired_qitem(queue_name):
+    '''
+    Retrieve a single unretired queued item, if one exists, from the named queue
+
+    Returns (success, qitem):
+        success: Flag whether retrieval is successful (Boolean)
+                 If no unretired item in the queue, return False
+        qitem:   Retrieved, unretired queue item
+    '''
+    pass
+
 def get_single_qitem(queue_name):
     '''
     Retrieve a single queued item, if one exists, from the named queue

--- a/queue/consumer.py
+++ b/queue/consumer.py
@@ -169,10 +169,10 @@ class SingleChannel(threading.Thread):
             log.error("Submission {} to grader {} failure: Reply: {}, ".format(submission_id, self.workerURL, grader_reply))
             submission.num_failures += 1
             submission.lms_ack = post_failure_to_lms(submission.xqueue_header)
-        submission.retired = True
+
+        submission.retired = True # NOTE: Retiring pushed submissions after one shot regardless of grading_success
 
         submission.save()
-        print submission
 
         # Take item off of queue.
         ch.basic_ack(delivery_tag=method.delivery_tag)

--- a/queue/consumer.py
+++ b/queue/consumer.py
@@ -57,11 +57,11 @@ def post_failure_to_lms(header):
     
     # This is the only part of the XQueue that assumes knowledge of the external 
     #   grader message format. TODO: Make the notification message-format agnostic
-    msg  = '<span>'
+    msg  = '<div class="capa_alert">'
     msg += 'Your submission could not be graded. '
     msg += 'Please recheck your submission and try again. '
     msg += 'If the problem persists, please notify the course staff.'
-    msg += '</span>'
+    msg += '</div>'
     failure_msg = { 'correct': None,
                     'score': 0,
                     'msg': msg }

--- a/queue/consumer.py
+++ b/queue/consumer.py
@@ -162,28 +162,30 @@ class SingleChannel(threading.Thread):
             ))
             return  # Just move on
 
-        # Deliver job to worker
-        payload = {'xqueue_body': submission.xqueue_body,
-                   'xqueue_files': submission.s3_urls}
+        # If item has been retired, skip grading
+        if not submission.retired:
+            # Deliver job to worker
+            payload = {'xqueue_body': submission.xqueue_body,
+                       'xqueue_files': submission.s3_urls}
 
-        submission.grader_id = self.workerURL
-        submission.push_time = timezone.now()
-        (grading_success, grader_reply) = _http_post(self.workerURL, json.dumps(payload))
-        submission.return_time = timezone.now()
+            submission.grader_id = self.workerURL
+            submission.push_time = timezone.now()
+            (grading_success, grader_reply) = _http_post(self.workerURL, json.dumps(payload))
+            submission.return_time = timezone.now()
 
-        # TODO: For the time being, a submission in a push interface gets one chance at grading,
-        #       with no requeuing logic
-        if grading_success:
-            submission.grader_reply = grader_reply
-            submission.lms_ack = post_grade_to_lms(submission.xqueue_header, grader_reply)
-        else:
-            log.error("Submission {} to grader {} failure: Reply: {}, ".format(submission_id, self.workerURL, grader_reply))
-            submission.num_failures += 1
-            submission.lms_ack = post_failure_to_lms(submission.xqueue_header)
+            # TODO: For the time being, a submission in a push interface gets one chance at grading,
+            #       with no requeuing logic
+            if grading_success:
+                submission.grader_reply = grader_reply
+                submission.lms_ack = post_grade_to_lms(submission.xqueue_header, grader_reply)
+            else:
+                log.error("Submission {} to grader {} failure: Reply: {}, ".format(submission_id, self.workerURL, grader_reply))
+                submission.num_failures += 1
+                submission.lms_ack = post_failure_to_lms(submission.xqueue_header)
 
-        submission.retired = True # NOTE: Retiring pushed submissions after one shot regardless of grading_success
+            submission.retired = True # NOTE: Retiring pushed submissions after one shot regardless of grading_success
 
-        submission.save()
+            submission.save()
 
-        # Take item off of queue.
+        # Take item off of queue
         ch.basic_ack(delivery_tag=method.delivery_tag)

--- a/queue/consumer.py
+++ b/queue/consumer.py
@@ -168,6 +168,7 @@ class SingleChannel(threading.Thread):
         else:
             log.error("Submission {} to grader {} failure: Reply: {}, ".format(submission_id, self.workerURL, grader_reply))
             submission.num_failures += 1
+            submission.lms_ack = post_failure_to_lms(submission.xqueue_header)
         submission.retired = True
 
         submission.save()

--- a/queue/ext_interface.py
+++ b/queue/ext_interface.py
@@ -72,6 +72,9 @@ def get_submission(request):
                 ))
                 return HttpResponse(compose_reply(False, "Error with queued submission. Please try again"))
 
+            if submission.retired:
+                print 'Submission was invalidated!'
+
             pullkey = make_hashkey(str(pull_time)+qitem)
             
             submission.grader_id = grader_id

--- a/queue/ext_interface.py
+++ b/queue/ext_interface.py
@@ -1,17 +1,17 @@
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponse 
+from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.utils import timezone
 
 import json
 import logging
 
-from queue.models import Submission 
+from queue.models import Submission
 from queue.views import compose_reply
 from util import *
 
-import queue.producer 
+import queue.producer
 import queue.consumer
 
 log = logging.getLogger(__name__)

--- a/queue/ext_interface.py
+++ b/queue/ext_interface.py
@@ -82,7 +82,7 @@ def get_submission(request):
 
             # Prepare payload to external grader
             ext_header = {'submission_id':submission_id, 'submission_key':pullkey} 
-            
+
             payload = {'xqueue_header': json.dumps(ext_header),
                        'xqueue_body': submission.xqueue_body,
                        'xqueue_files': submission.s3_urls} 
@@ -131,7 +131,6 @@ def put_result(request):
             submission.retired = submission.lms_ack
 
             submission.save()
-            print submission
 
             return HttpResponse(compose_reply(success=True, content=''))
 

--- a/queue/ext_interface.py
+++ b/queue/ext_interface.py
@@ -72,9 +72,6 @@ def get_submission(request):
                 ))
                 return HttpResponse(compose_reply(False, "Error with queued submission. Please try again"))
 
-            if submission.retired:
-                print 'Submission was invalidated!'
-
             pullkey = make_hashkey(str(pull_time)+qitem)
             
             submission.grader_id = grader_id

--- a/queue/ext_interface.py
+++ b/queue/ext_interface.py
@@ -121,15 +121,17 @@ def put_result(request):
 
             if not submission.pullkey or submission_key != submission.pullkey:
                 return HttpResponse(compose_reply(False,'Incorrect key for submission'))
-            
+
             submission.return_time = timezone.now()
-            submission.pullkey = '' 
+            submission.pullkey = ''
             submission.grader_reply = grader_reply
 
             # Deliver grading results to LMS
             submission.lms_ack = queue.consumer.post_grade_to_lms(submission.xqueue_header, grader_reply)
+            submission.retired = submission.lms_ack
 
             submission.save()
+            print submission
 
             return HttpResponse(compose_reply(success=True, content=''))
 
@@ -166,5 +168,5 @@ def _is_valid_reply(external_reply):
             return fail
 
     submission_id  = int(header_dict['submission_id'])
-    submission_key = header_dict['submission_key'] 
-    return (True, submission_id, submission_key, score_msg) 
+    submission_key = header_dict['submission_key']
+    return (True, submission_id, submission_key, score_msg)

--- a/queue/lms_interface.py
+++ b/queue/lms_interface.py
@@ -48,17 +48,19 @@ def submit(request):
                     s3_urls.update({filename: s3_url})
 
                 # Track the submission in the Submission database
-                submission = Submission(requester_id=get_request_ip(request),    
+                submission = Submission(requester_id=get_request_ip(request),
+                                        lms_callback_url=lms_callback_url,
                                         queue_name=queue_name,
                                         xqueue_header=xqueue_header,
                                         xqueue_body=xqueue_body,
                                         s3_urls=json.dumps(s3_urls),
                                         s3_keys=json.dumps(s3_keys))
                 submission.save()
+                print submission
 
                 qitem  = str(submission.id) # Submit the Submission pointer to queue
                 qcount = queue.producer.push_to_queue(queue_name, qitem)
-                
+
                 # For a successful submission, return the count of prior items
                 return HttpResponse(compose_reply(success=True, content="%d" % qcount))
         

--- a/queue/management/commands/requeue_pulled_submissions.py
+++ b/queue/management/commands/requeue_pulled_submissions.py
@@ -18,12 +18,12 @@ class Command(BaseCommand):
         log.info(' [*] Running requeue of pulled submissions...')
 
         if len(args) == 0:
-            open_submissions = Submission.objects.filter(lms_ack=False)
+            open_submissions = Submission.objects.filter(retired=False)
             open_submissions = open_submissions.exclude(pull_time=None)
             self.requeue_submissions(open_submissions)
         else:
             for queue_name in args:
-                open_submissions = Submission.objects.filter(queue_name=queue_name, lms_ack=False)
+                open_submissions = Submission.objects.filter(queue_name=queue_name, retired=False)
                 open_submissions = open_submissions.exclude(pull_time=None)
                 self.requeue_submissions(open_submissions)
 

--- a/queue/management/commands/retire_submissions.py
+++ b/queue/management/commands/retire_submissions.py
@@ -25,14 +25,16 @@ class Command(BaseCommand):
         log.info(' [*] Scanning Submission database to retire failed submissions...')
         
         force = options['force']
+        if force:
+            log.info(" [ ] Force retiring all failed submissions...")
 
         if len(args) == 0:
-            failed_submissions = Submission.objects.filter(lms_ack=False)
+            failed_submissions = Submission.objects.filter(retired=False)
             failed_submissions = failed_submissions.exclude(num_failures=0)
             self.retire_submissions(failed_submissions, force)
         else:
             for queue_name in args:
-                failed_submissions = Submission.objects.filter(queue_name=queue_name, lms_ack=False)
+                failed_submissions = Submission.objects.filter(queue_name=queue_name, retired=False)
                 failed_submissions = failed_submissions.exclude(num_failures=0)
                 self.retire_submissions(failed_submissions, force)
         
@@ -43,10 +45,10 @@ class Command(BaseCommand):
                 log.info(" [ ] Retiring submission id=%d from queue '%s' with num_failures=%d" %\
                             (failed_submission.id, failed_submission.queue_name, failed_submission.num_failures))
                 if force:
-                    log.info(" [ ] Force retiring all failed submissions...")
-                    failed_submission.lms_ack = True # Mark as done without contacting LMS
+                    failed_submission.retired = True # Mark as done without contacting LMS
                 else:
                     failed_submission.lms_ack = post_failure_to_lms(failed_submission.xqueue_header)
+                    failed_submission.retired = failed_submission.lms_ack
                     if not failed_submission.lms_ack:
                         log.error(' [ ] Could not contact LMS to retire submission id=%d' % failed_submission.id)
                 failed_submission.save()

--- a/queue/migrations/0001_initial.py
+++ b/queue/migrations/0001_initial.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Submission'
+        db.create_table('queue_submission', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('requester_id', self.gf('django.db.models.fields.CharField')(max_length=128)),
+            ('queue_name', self.gf('django.db.models.fields.CharField')(max_length=128)),
+            ('xqueue_header', self.gf('django.db.models.fields.CharField')(max_length=1024)),
+            ('xqueue_body', self.gf('django.db.models.fields.TextField')()),
+            ('s3_keys', self.gf('django.db.models.fields.CharField')(max_length=1024)),
+            ('s3_urls', self.gf('django.db.models.fields.CharField')(max_length=1024)),
+            ('arrival_time', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, blank=True)),
+            ('pull_time', self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True)),
+            ('push_time', self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True)),
+            ('return_time', self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True)),
+            ('grader_id', self.gf('django.db.models.fields.CharField')(max_length=128)),
+            ('pullkey', self.gf('django.db.models.fields.CharField')(max_length=128)),
+            ('grader_reply', self.gf('django.db.models.fields.TextField')()),
+            ('num_failures', self.gf('django.db.models.fields.IntegerField')(default=0)),
+            ('lms_ack', self.gf('django.db.models.fields.BooleanField')(default=False)),
+        ))
+        db.send_create_signal('queue', ['Submission'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'Submission'
+        db.delete_table('queue_submission')
+
+
+    models = {
+        'queue.submission': {
+            'Meta': {'object_name': 'Submission'},
+            'arrival_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'grader_id': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'grader_reply': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'lms_ack': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'num_failures': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'pull_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'pullkey': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'push_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'queue_name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'requester_id': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'return_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            's3_keys': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            's3_urls': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'xqueue_body': ('django.db.models.fields.TextField', [], {}),
+            'xqueue_header': ('django.db.models.fields.CharField', [], {'max_length': '1024'})
+        }
+    }
+
+    complete_apps = ['queue']

--- a/queue/migrations/0002_auto__add_field_submission_lms_callback_url.py
+++ b/queue/migrations/0002_auto__add_field_submission_lms_callback_url.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Submission.lms_callback_url'
+        db.add_column('queue_submission', 'lms_callback_url',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=128),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Submission.lms_callback_url'
+        db.delete_column('queue_submission', 'lms_callback_url')
+
+
+    models = {
+        'queue.submission': {
+            'Meta': {'object_name': 'Submission'},
+            'arrival_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'grader_id': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'grader_reply': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'lms_ack': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'lms_callback_url': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'num_failures': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'pull_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'pullkey': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'push_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'queue_name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'requester_id': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'return_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            's3_keys': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            's3_urls': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'xqueue_body': ('django.db.models.fields.TextField', [], {}),
+            'xqueue_header': ('django.db.models.fields.CharField', [], {'max_length': '1024'})
+        }
+    }
+
+    complete_apps = ['queue']

--- a/queue/migrations/0003_auto__add_field_submission_retired.py
+++ b/queue/migrations/0003_auto__add_field_submission_retired.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Submission.retired'
+        db.add_column('queue_submission', 'retired',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Submission.retired'
+        db.delete_column('queue_submission', 'retired')
+
+
+    models = {
+        'queue.submission': {
+            'Meta': {'object_name': 'Submission'},
+            'arrival_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'grader_id': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'grader_reply': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'lms_ack': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'lms_callback_url': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'num_failures': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'pull_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'pullkey': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'push_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'queue_name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'requester_id': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'retired': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'return_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            's3_keys': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            's3_urls': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'xqueue_body': ('django.db.models.fields.TextField', [], {}),
+            'xqueue_header': ('django.db.models.fields.CharField', [], {'max_length': '1024'})
+        }
+    }
+
+    complete_apps = ['queue']

--- a/queue/migrations/0003_auto__add_field_submission_retired.py
+++ b/queue/migrations/0003_auto__add_field_submission_retired.py
@@ -10,7 +10,7 @@ class Migration(SchemaMigration):
     def forwards(self, orm):
         # Adding field 'Submission.retired'
         db.add_column('queue_submission', 'retired',
-                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
                       keep_default=False)
 
 

--- a/queue/models.py
+++ b/queue/models.py
@@ -9,7 +9,6 @@ class Submission(models.Model):
     '''
     Representation of submission request, including metadata information
     '''
-    
     # Submission 
     requester_id     = models.CharField(max_length=CHARFIELD_LEN_SMALL) # ID of LMS
     lms_callback_url = models.CharField(max_length=CHARFIELD_LEN_SMALL)
@@ -35,6 +34,7 @@ class Submission(models.Model):
     # Status
     num_failures = models.IntegerField(default=0) # Number of failures in exchange with external grader
     lms_ack = models.BooleanField(default=False)  # True/False on whether LMS acknowledged receipt
+    retired = models.BooleanField(default=False)  # True/False on whether Submission is "finished"
 
     def __unicode__(self):
         submission_info  = "Submission from %s for queue '%s':\n" % (self.requester_id, self.queue_name)

--- a/queue/models.py
+++ b/queue/models.py
@@ -47,6 +47,7 @@ class Submission(models.Model):
         submission_info += "    Pullkey:      %s\n" % self.pullkey
         submission_info += "    num_failures: %d\n" % self.num_failures
         submission_info += "    lms_ack:      %s\n" % self.lms_ack
+        submission_info += "    retired:      %s\n" % self.retired
         submission_info += "Original Xqueue header follows:\n"
         submission_info += json.dumps(json.loads(self.xqueue_header), indent=4)
         return submission_info

--- a/queue/models.py
+++ b/queue/models.py
@@ -38,6 +38,7 @@ class Submission(models.Model):
 
     def __unicode__(self):
         submission_info  = "Submission from %s for queue '%s':\n" % (self.requester_id, self.queue_name)
+        submission_info += "    Callback URL: %s\n" % self.lms_callback_url
         submission_info += "    Arrival time: %s\n" % self.arrival_time
         submission_info += "    Pull time:    %s\n" % self.pull_time
         submission_info += "    Push time:    %s\n" % self.push_time

--- a/queue/models.py
+++ b/queue/models.py
@@ -11,10 +11,11 @@ class Submission(models.Model):
     '''
     
     # Submission 
-    requester_id  = models.CharField(max_length=CHARFIELD_LEN_SMALL) # ID of LMS
-    queue_name    = models.CharField(max_length=CHARFIELD_LEN_SMALL)
-    xqueue_header = models.CharField(max_length=CHARFIELD_LEN_LARGE)
-    xqueue_body   = models.TextField()
+    requester_id     = models.CharField(max_length=CHARFIELD_LEN_SMALL) # ID of LMS
+    lms_callback_url = models.CharField(max_length=CHARFIELD_LEN_SMALL)
+    queue_name       = models.CharField(max_length=CHARFIELD_LEN_SMALL)
+    xqueue_header    = models.CharField(max_length=CHARFIELD_LEN_LARGE)
+    xqueue_body      = models.TextField()
 
     # Uploaded files
     s3_keys = models.CharField(max_length=CHARFIELD_LEN_LARGE) # S3 keys for internal Xqueue use

--- a/queue/tests.py
+++ b/queue/tests.py
@@ -62,7 +62,7 @@ class lms_interface_test(unittest.TestCase):
                                                      'lms_key':'qwerty',
                                                      'queue_name':'python'}),
                         'xqueue_body': 'def square(x):\n    return n**2'}
-        (is_valid,_,_,_) = lms_interface._is_valid_request(good_request)
+        (is_valid,_,_,_,_) = lms_interface._is_valid_request(good_request)
         self.assertEqual(is_valid, True)
 
         # 1) Header is missing
@@ -88,7 +88,7 @@ class lms_interface_test(unittest.TestCase):
 
         bad_requests = [bad_request1, bad_request2, bad_request3, bad_request4, bad_request5, bad_request6]
         for bad_request in bad_requests:
-            (is_valid,_,_,_) = lms_interface._is_valid_request(bad_request)
+            (is_valid,_,_,_,_) = lms_interface._is_valid_request(bad_request)
             self.assertEqual(is_valid, False)
 
 

--- a/xqueue/settings.py
+++ b/xqueue/settings.py
@@ -143,6 +143,7 @@ INSTALLED_APPS = (
     # Uncomment the next line to enable admin documentation:
     # 'django.contrib.admindocs',
     'queue',
+    'south',
 )
 
 LOGIN_URL = '/xqueue/login'

--- a/xqueue/settings.py
+++ b/xqueue/settings.py
@@ -19,7 +19,8 @@ MANAGERS = ADMINS
 
 REQUESTS_TIMEOUT = 1 # seconds
 
-XQUEUES = {'test-pull': None}
+XQUEUES = {'MITx-6.00x': 'http://ec2-23-22-89-106.compute-1.amazonaws.com',
+           'test-pull': None}
 XQUEUE_WORKERS_PER_QUEUE = 4
 
 MAX_NUMBER_OF_FAILURES = 3


### PR DESCRIPTION
Queue-side DOS prevention. Idea:
- Submissions are tracked on a StudentModule (i.e. (user,module-id)) basis, which has a 1-to-1 mapping to the LMS callback URL. Note that we may want to strip the protocol and the base URL from the comparison URL, e.g. `http://www.edx.org/path/to/<user>/<id>/score_update` to `/path/to/<user>/<id>/score_update`.

This pull request requires a DB migration of the queue service: two new columns are added. 
- `lms_callback_url`, so that we can query on it directly (previously, it was in a json.dump field called `xqueue_header`) 
- `retired` Boolean flag that marks a submission as being "done." (I've been using the term "retired.") In the migration of existing data, the retired flag should be marked as `True` in order to avoid replay of prior submissions.

For the push interface (i.e. 6.00x), the functional changes:
- If you pool a large number of submissions from a single StudentModule, then only the latest submission will actually be sent to the external grader.
- If the external push fails, the LMS will immediately be informed of the failure.

For the pull interface (i.e. Berkeley), the functional changes:
- The API is unaffected, so Berkeley doesn't need to change anything on their side.
- The API call `get_submission` will only deliver unretired submissions to the external grader.

Internal to the queue service:
- The management commands `retire_submissions` and `requeue_pulled_submissions` make use of the new `retired` column rather than the previously overloaded `lms_ack`.

TODO:
- The API call `get_queuelen` does not distinguish between retired and unretired submissions. 
