### PR TITLE
Remove the transaction from the consumer code.

### DIFF
--- a/queue/consumer.py
+++ b/queue/consumer.py
@@ -192,10 +192,6 @@ class SingleChannel(threading.Thread):
         try:
             submission = Submission.objects.get(id=submission_id)
         except Submission.DoesNotExist:
-            # We'll complain about it soon...
-            pass
-
-        if submission == None:
             ch.basic_ack(delivery_tag=method.delivery_tag)
             statsd.increment('xqueue.consumer.consumer_callback.submission_does_not_exist',
                              tags=['queue:{0}'.format(self.queue_name)])


### PR DESCRIPTION
- it should not be triggered now that we have proper behavior in the producer,
  and the transaction.commit_manually wrapper obscures exception logging
