### PR TITLE
Long s3 urls

### DIFF
--- a/queue/migrations/0006_long_s3_urls.py
+++ b/queue/migrations/0006_long_s3_urls.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'Submission.s3_urls'
+        db.alter_column('queue_submission', 's3_urls', self.gf('django.db.models.fields.TextField')())
+
+        # Changing field 'Submission.s3_keys'
+        db.alter_column('queue_submission', 's3_keys', self.gf('django.db.models.fields.TextField')())
+
+    def backwards(self, orm):
+
+        # Changing field 'Submission.s3_urls'
+        db.alter_column('queue_submission', 's3_urls', self.gf('django.db.models.fields.CharField')(max_length=1024))
+
+        # Changing field 'Submission.s3_keys'
+        db.alter_column('queue_submission', 's3_keys', self.gf('django.db.models.fields.CharField')(max_length=1024))
+
+    models = {
+        'queue.submission': {
+            'Meta': {'object_name': 'Submission'},
+            'arrival_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'grader_id': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'grader_reply': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'lms_ack': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'lms_callback_url': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'num_failures': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'pull_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'pullkey': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'push_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'queue_name': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'requester_id': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'retired': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'return_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            's3_keys': ('django.db.models.fields.TextField', [], {}),
+            's3_urls': ('django.db.models.fields.TextField', [], {}),
+            'xqueue_body': ('django.db.models.fields.TextField', [], {}),
+            'xqueue_header': ('django.db.models.fields.CharField', [], {'max_length': '1024'})
+        }
+    }
+
+    complete_apps = ['queue']

--- a/queue/models.py
+++ b/queue/models.py
@@ -23,8 +23,8 @@ class Submission(models.Model):
     xqueue_body      = models.TextField()
 
     # Uploaded files
-    s3_keys = models.CharField(max_length=CHARFIELD_LEN_LARGE) # S3 keys for internal Xqueue use
-    s3_urls = models.CharField(max_length=CHARFIELD_LEN_LARGE) # S3 urls for external access
+    s3_keys = models.TextField() # S3 keys for internal Xqueue use
+    s3_urls = models.TextField() # S3 urls for external access
 
     # Timing
     arrival_time = models.DateTimeField(auto_now=True)         # Time of arrival from LMS


### PR DESCRIPTION
CS184.1x wants to upload up to 20 files at a time.

Allocating only 1024 characters to hold the serialized dict of s3 URLs is not enough when there are 20 files. So, convert the relevant fields to `TextField`
