### PR TITLE
Adding newrelic to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ path.py
 dogstatsd-python==0.2
 south
 MySQL-python
+newrelic


### PR DESCRIPTION
This is necessary now that we are running out of a virtualenv
on AWS, before newrelic was in the system path
