### PR TITLE
Adding heartbeat interval to pika connection parameters

### DIFF
--- a/queue/consumer.py
+++ b/queue/consumer.py
@@ -72,6 +72,7 @@ def get_single_qitem(queue_name):
                                             settings.RABBITMQ_PASS)
 
     connection = pika.BlockingConnection(pika.ConnectionParameters(
+        heartbeat_interval=5,
         credentials=credentials, host=settings.RABBIT_HOST))
     channel = connection.channel()
     channel.queue_declare(queue=queue_name, durable=True)
@@ -178,8 +179,8 @@ class SingleChannel(threading.Thread):
         credentials = pika.PlainCredentials(settings.RABBITMQ_USER,
                                                 settings.RABBITMQ_PASS)
         connection = pika.BlockingConnection(
-                        pika.ConnectionParameters(credentials=credentials,
-                        host=settings.RABBIT_HOST))
+                        pika.ConnectionParameters(heartbeat_interval=5,
+                            credentials=credentials, host=settings.RABBIT_HOST))
         channel = connection.channel()
         channel.queue_declare(queue=self.queue_name, durable=True)
         channel.basic_qos(prefetch_count=1)

--- a/queue/producer.py
+++ b/queue/producer.py
@@ -14,7 +14,8 @@ def push_to_queue(queue_name, qitem=None):
     credentials = pika.PlainCredentials(settings.RABBITMQ_USER,
                                             settings.RABBITMQ_PASS)
     connection = pika.BlockingConnection(pika.ConnectionParameters(
-        credentials=credentials, host=settings.RABBIT_HOST))
+        heartbeat_interval=5, credentials=credentials,
+        host=settings.RABBIT_HOST))
     channel = connection.channel()
     q = channel.queue_declare(queue=queue_name, durable=True)
     if qitem is not None:


### PR DESCRIPTION
This sets a heartbeat to the rabbitmq servers so that we can put them behind an ELB.
The timeout is set to 5 seconds.
