### PR TITLE
in run_consumer, restart channel if terminated unexpectedly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage.xml
 log
 nosetests.xml
 reports
+*~

--- a/queue/management/commands/run_consumer.py
+++ b/queue/management/commands/run_consumer.py
@@ -64,7 +64,12 @@ class Command(BaseCommand):
     help = "Listens to all queues specified as being push-queues in the django configuration with <worker count> processes"
 
     def handle(self, *args, **options):
+        log.info('====> run_consumer pid=%s' % os.getpid())
         log.info(' [*] Starting queue consumers...')
+
+        pidfn = getattr(settings,'QUEUE_CONSUMER_PID_FILE','')
+        if pidfn:
+            open(pidfn,'w').write(str(os.getpid()))
 
         channels = []
         queues = [


### PR DESCRIPTION
also add output of pid (to file specified by `settings.QUEUE_CONSUMER_PID_FILE`

auto-restart feature happens only of `settings.RUN_CONSUMER_FOREVER`
