### PR TITLE
Freeze to working versions for python-termstyle and rednose.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ nose==1.2.1
 nosexcover==1.0.7
 path.py==2.4.1
 -e git://github.com/pika/pika.git@a731347fc0#egg=pika
-python-termstyle==0.1.10
-rednose==0.3.3
+python-termstyle==0.1.9
+rednose==0.3
 requests==0.14.2
 wsgiref==0.1.2


### PR DESCRIPTION
Versions previously pinned to are no longer downloadable.
