### PR TITLE
Changed python-termstyle requirement to version 0.1.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ nose==1.2.1
 nosexcover==1.0.7
 path.py==2.4.1
 -e git://github.com/pika/pika.git@a731347fc0#egg=pika
-python-termstyle==0.1.9
+python-termstyle==0.1.10
 rednose==0.3
 requests==0.14.2
 wsgiref==0.1.2


### PR DESCRIPTION
Since the developer apparently deleted version 0.1.9 from PyPi:
https://pypi.python.org/pypi/python-termstyle/0.1.9

Oddly, I was still able to get version 0.1.9 installed when using pip version 1.3.  To recreate, make sure you are using pip >= 1.4 in a fresh virtualenv.

Reviewer: @feanil 
