### PR TITLE
config-prefix: Allow to specify SERVICE_VARIANT, used as config prefix

### DIFF
--- a/queue/management/commands/update_users.py
+++ b/queue/management/commands/update_users.py
@@ -8,6 +8,7 @@ Ensure that the right users exist:
 """
 import json
 import logging
+import os
 
 from django.core.management.base import BaseCommand
 from django.conf import settings
@@ -21,7 +22,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
 
         log.info("root is : " + settings.ENV_ROOT)
-        auth_path = settings.ENV_ROOT / "auth.json"
+        auth_filename = '{0}auth.json'.format(settings.CONFIG_PREFIX)
+        auth_path = os.path.join(settings.ENV_ROOT, auth_filename)
 
         log.info(' [*] reading {0}'.format(auth_path))
 

--- a/xqueue/aws_settings.py
+++ b/xqueue/aws_settings.py
@@ -2,7 +2,12 @@ from settings import *
 import json
 from logsettings import get_logger_config
 
-with open(ENV_ROOT / "env.json") as env_file:
+# Allow to specify a prefix for env/auth configuration files
+SERVICE_VARIANT = os.environ.get('SERVICE_VARIANT', '')
+if SERVICE_VARIANT:
+    CONFIG_PREFIX = SERVICE_VARIANT + "."
+
+with open(ENV_ROOT / CONFIG_PREFIX + "env.json") as env_file:
     ENV_TOKENS = json.load(env_file)
 
 XQUEUES = ENV_TOKENS['XQUEUES']
@@ -21,7 +26,7 @@ LOGGING = get_logger_config(LOG_DIR,
 
 RABBIT_HOST = ENV_TOKENS.get('RABBIT_HOST', RABBIT_HOST).encode('ascii')
 
-with open(ENV_ROOT / "auth.json") as auth_file:
+with open(ENV_ROOT / CONFIG_PREFIX + "auth.json") as auth_file:
     AUTH_TOKENS = json.load(auth_file)
 
 DATABASES = AUTH_TOKENS['DATABASES']

--- a/xqueue/settings.py
+++ b/xqueue/settings.py
@@ -5,6 +5,7 @@ from path import path
 ROOT_PATH = path(__file__).dirname()
 REPO_PATH = ROOT_PATH.dirname()
 ENV_ROOT = REPO_PATH.dirname()
+CONFIG_PREFIX = ''
 
 # Django settings for xqueue project.
 


### PR DESCRIPTION
Several services are currently using the same configuration filenames `/opt/wwc/env.json` & `/opt/wwc/auth.json` files. The configuration files would get overwritten when this is used by several different services cohabiting on a single instance. This patch allows to use the same convention as on the LMS/CMS (role edxapp on the configuration repository) to prefix the configuration files, with the `SERVICE_VARIANT` environment variable.

Cf https://github.com/edx/configuration/pull/234
