### PR TITLE
allow ora (or other pull-grader) to repeat (amend) its reply

### DIFF
--- a/queue/ext_interface.py
+++ b/queue/ext_interface.py
@@ -136,7 +136,6 @@ def put_result(request):
                 return HttpResponse(compose_reply(False,'Incorrect key for submission'))
 
             submission.return_time = timezone.now()
-            submission.pullkey = ''
             submission.grader_reply = grader_reply
 
             # Deliver grading results to LMS


### PR DESCRIPTION
@rocha 

This one line changes allows a pull grader to repeat a call to put_result (with potentially different result), which will be plumbed back through to the lms.

Doing this because we want to peer grading responses to be returned potentially incrementally, over several replies (each one a superset of the previous).
