### PR TITLE
Force consumer to die when connection to RabbitMQ is closed.

### DIFF
--- a/queue/xqueue_client.py
+++ b/queue/xqueue_client.py
@@ -1,4 +1,3 @@
-
 import datetime
 import json
 import logging


### PR DESCRIPTION
We are seeing instances where we detect a disconnect, try to
reconnect to RabbitMQ, and then fail to do so. The reconnection
code fails without error and the worker gracefully exits, bypassing
the monitor code that would restart it. This change causes us to
always throw an FailOnDisconnectError when we get a disconnect,
which causes the worker to die. The monitor will then restart it.

[LMS-1612]

@rocha, @e0d 
