### PR TITLE
add rabbitmq virtual host parameterization

### DIFF
--- a/queue/consumer.py
+++ b/queue/consumer.py
@@ -91,7 +91,8 @@ def get_single_qitem(queue_name):
 
     connection = pika.BlockingConnection(pika.ConnectionParameters(
         heartbeat_interval=5,
-        credentials=credentials, host=settings.RABBIT_HOST))
+        credentials=credentials, host=settings.RABBIT_HOST,
+        virtual_host=settings.RABBIT_VHOST))
     channel = connection.channel()
     channel.queue_declare(queue=queue_name, durable=True)
 

--- a/queue/producer.py
+++ b/queue/producer.py
@@ -24,7 +24,8 @@ def push_to_queue(queue_name, qitem=None):
 
     parameters = pika.ConnectionParameters(heartbeat_interval=5,
                                            credentials=credentials,
-                                           host=settings.RABBIT_HOST)
+                                           host=settings.RABBIT_HOST,
+                                           virtual_host=settings.RABBIT_VHOST)
 
     retries = 0
     while True:

--- a/test_framework/integration_framework.py
+++ b/test_framework/integration_framework.py
@@ -164,7 +164,8 @@ class GraderStubBase(object):
                                       settings.RABBITMQ_PASS)
 
         params = pika.ConnectionParameters(credentials=creds,
-                                           host=settings.RABBIT_HOST)
+                                           host=settings.RABBIT_HOST,
+                                           virtual_host=settings.RABBIT_VHOST)
 
         connection = pika.BlockingConnection(parameters=params)
         channel = connection.channel()

--- a/xqueue/aws_settings.py
+++ b/xqueue/aws_settings.py
@@ -27,7 +27,7 @@ LOGGING = get_logger_config(LOG_DIR,
                             debug=False)
 
 RABBIT_HOST = ENV_TOKENS.get('RABBIT_HOST', RABBIT_HOST).encode('ascii')
-
+RABBIT_VHOST = ENV_TOKENS.get('RABBIT_VHOST', RABBIT_VHOST).encode('ascii')
 with open(ENV_ROOT / CONFIG_PREFIX + "auth.json") as auth_file:
     AUTH_TOKENS = json.load(auth_file)
 

--- a/xqueue/settings.py
+++ b/xqueue/settings.py
@@ -40,6 +40,7 @@ DATABASES = {
     }
 }
 RABBIT_HOST = 'localhost'
+RABBIT_VHOST = '/' # defaults to '/', otherwise a string
 
 AWS_ACCESS_KEY_ID = "access_key_id"
 AWS_SECRET_ACCESS_KEY = "secret_access_key"

--- a/xqueue/test_settings.py
+++ b/xqueue/test_settings.py
@@ -62,7 +62,7 @@ except (IOError, ValueError):
 RABBITMQ_USER = ENV_TOKENS.get('RABBITMQ_USER', 'guest')
 RABBITMQ_PASS = ENV_TOKENS.get('RABBITMQ_PASS', 'guest')
 RABBIT_HOST = ENV_TOKENS.get('RABBIT_HOST', 'localhost')
-
+RABBIT_VHOST = ENV_TOKENS.get('RABBIT_VHOST', '/')
 # Mathworks setup
 # We load the Mathworks settings from envs.json
 # to avoid storing auth information in the repository


### PR DESCRIPTION
@rocha 
Adding rabbitmq virtual-host configurability.  Defaults to '/' which should be the default vhost.  @wedaly I'm pretty sure this won't break your test setup, right?
