### PR TITLE
Add missing rabbitmq VHOST parameter in worker class

### DIFF
--- a/queue/consumer.py
+++ b/queue/consumer.py
@@ -215,7 +215,8 @@ class Worker(multiprocessing.Process):
 
         self.parameters = pika.ConnectionParameters(heartbeat_interval=5,
                                                     credentials=credentials,
-                                                    host=settings.RABBIT_HOST)
+                                                    host=settings.RABBIT_HOST,
+                                                    virtual_host=settings.RABBIT_VHOST)
         self.channel = None
         self.connection = None
 


### PR DESCRIPTION
It looks like one got missed from PR #74, adding it.

@jbau @rocha
