### PR TITLE
change requirements to use git https clone

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Felix Sun <felixsun@mit.edu>
 Carson Gee <x@carsongee.com>
 Xavier Antoviaque <xavier@antoviaque.org>
 Jason Bau <jbau@stanford.edu>
+Xiang Junfu <xiangjf.fnst@cn.fujitsu.com>

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ newrelic==2.18.1.15
 nose==1.2.1
 nosexcover==1.0.7
 path.py==2.4.1
--e git://github.com/pika/pika.git@a731347fc0#egg=pika
+-e git+https://github.com/pika/pika.git@a731347fc0#egg=pika
 python-termstyle==0.1.10
 rednose==0.3
 requests==0.14.2


### PR DESCRIPTION
Change requirements line for pika to use git https clone, as many corporates' firewall blocks the port for git protocol.
Also, requirements of other repos in edx use https clone as well.
