### PR TITLE
increase lms_callback_url field length

### DIFF
--- a/queue/migrations/0006_auto__chg_field_submission_lms_callback_url.py
+++ b/queue/migrations/0006_auto__chg_field_submission_lms_callback_url.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'Submission.lms_callback_url'
+        db.alter_column('queue_submission', 'lms_callback_url', self.gf('django.db.models.fields.CharField')(max_length=255))
+
+    def backwards(self, orm):
+
+        # Changing field 'Submission.lms_callback_url'
+        db.alter_column('queue_submission', 'lms_callback_url', self.gf('django.db.models.fields.CharField')(max_length=128))
+
+    models = {
+        'queue.submission': {
+            'Meta': {'object_name': 'Submission'},
+            'arrival_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'grader_id': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'grader_reply': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'lms_ack': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'lms_callback_url': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'num_failures': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'pull_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'pullkey': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'push_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'queue_name': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'requester_id': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'retired': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'return_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            's3_keys': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            's3_urls': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'xqueue_body': ('django.db.models.fields.TextField', [], {}),
+            'xqueue_header': ('django.db.models.fields.CharField', [], {'max_length': '1024'})
+        }
+    }
+
+    complete_apps = ['queue']

--- a/queue/models.py
+++ b/queue/models.py
@@ -9,6 +9,7 @@ from django.db import models
 import json
 
 CHARFIELD_LEN_SMALL = 128
+CHARFIELD_LEN_MEDIUM = 255
 CHARFIELD_LEN_LARGE = 1024
 
 class Submission(models.Model):
@@ -17,7 +18,7 @@ class Submission(models.Model):
     '''
     # Submission 
     requester_id     = models.CharField(max_length=CHARFIELD_LEN_SMALL) # ID of LMS
-    lms_callback_url = models.CharField(max_length=CHARFIELD_LEN_SMALL, db_index=True)
+    lms_callback_url = models.CharField(max_length=CHARFIELD_LEN_MEDIUM, db_index=True)
     queue_name       = models.CharField(max_length=CHARFIELD_LEN_SMALL, db_index=True)
     xqueue_header    = models.CharField(max_length=CHARFIELD_LEN_LARGE)
     xqueue_body      = models.TextField()


### PR DESCRIPTION
In django 1.4,  a model's field value gets truncated if it exceeds `max_length` limit but django 1.8 raises exception if we try to do this. We need to do this before [upgrading to django 1.8](https://github.com/edx/xqueue/pull/98)
