### PR TITLE
truncate lms_callback_url to 128

### DIFF
--- a/queue/lms_interface.py
+++ b/queue/lms_interface.py
@@ -73,7 +73,7 @@ def submit(request):
 
                 # Track the submission in the Submission database
                 submission = Submission(requester_id=get_request_ip(request),
-                                        lms_callback_url=lms_callback_url,
+                                        lms_callback_url=lms_callback_url[:128],
                                         queue_name=queue_name,
                                         xqueue_header=xqueue_header,
                                         xqueue_body=xqueue_body,


### PR DESCRIPTION
This is needed for Django 1.8.

Please see the details at 
https://github.com/edx/xqueue/pull/99
https://github.com/edx/xqueue/pull/98#discussion_r39977589
