### PR TITLE
execute select_for_update inside atomic block

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
   - pip install -r pre-requirements.txt
   - pip install -r requirements.txt
 services:
+  - mysql
   - rabbitmq
 env:
   - DJANGO_SETTINGS_MODULE=xqueue.settings

--- a/queue/ext_interface.py
+++ b/queue/ext_interface.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.db import transaction
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.utils import timezone
@@ -122,7 +123,8 @@ def put_result(request):
             return HttpResponse(compose_reply(False, 'Incorrect reply format'))
         else:
             try:
-                submission = Submission.objects.select_for_update().get(id=submission_id)
+                with transaction.atomic():
+                    submission = Submission.objects.select_for_update().get(id=submission_id)
             except Submission.DoesNotExist:
                 log.error("Grader submission_id refers to nonexistent entry in Submission DB: grader: {0}, submission_id: {1}, submission_key: {2}, grader_reply: {3}".format(
                     get_request_ip(request), 

--- a/xqueue/test_settings.py
+++ b/xqueue/test_settings.py
@@ -19,8 +19,8 @@ LOGGING = get_logger_config(log_dir,
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': 'test_xqueue.sqlite',
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'test_xqueue',
 
         # We need to use TEST_NAME here,
         # otherwise Django tests will use an in-memory database 
@@ -28,7 +28,7 @@ DATABASES = {
         # multiple threads, which the integration tests need.
         # We also need to choose *unique* names to avoid
         # conflicts in the Jenkins server
-        'TEST_NAME': 'test_xqueue_%s.sqlite' % uuid4().hex,
+        'TEST_NAME': 'test_xqueue_%s' % uuid4().hex,
     }
 }
 


### PR DESCRIPTION
The issue is [select_for_update](https://github.com/edx/xqueue/blob/master/queue/ext_interface.py#L125) should be inside an atomic block. The issue is always there and why it wasn't captured earlier because select_for_update is not supported for sqlite and we are using sqlite on travis. In the case of sqlite Django will not raise an exception.
https://docs.djangoproject.com/en/1.8/ref/models/querysets/#select-for-update

I am feeling bad for sqlite, we should not use sqlite for testing.
