### PR TITLE
Make put_result atomic in order to use select_for_update in django 1.6+

### DIFF
--- a/queue/ext_interface.py
+++ b/queue/ext_interface.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.db import transaction
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.utils import timezone
@@ -109,6 +110,7 @@ def get_submission(request):
             return HttpResponse(compose_reply(True, content=json.dumps(payload)))
 
 
+@transaction.atomic
 @csrf_exempt
 @login_required
 @statsd.timed('xqueue.ext_interface.put_result.time')


### PR DESCRIPTION
Since django version was bumped to 1.8 from 1.4 some bugs still to be catched.

As I updated my instance of xqueue put_result stopped working. And the exception I got was related to `Submission.select_for_update()`. 

Since django 1.6 the behaviour was changed and from then on `select_for_update` can be used only within transaction. As a solution a block containing submission select and update can be marked atomic. This commits wraps the whole put_result handler atomic.

For more information see: http://stackoverflow.com/questions/17149587/select-for-update-in-development-django
