### PR TITLE
Allow configuring RabbitMQ to use TLS

### DIFF
--- a/queue/consumer.py
+++ b/queue/consumer.py
@@ -93,8 +93,11 @@ def get_single_qitem(queue_name):
 
     connection = pika.BlockingConnection(pika.ConnectionParameters(
         heartbeat_interval=5,
-        credentials=credentials, host=settings.RABBIT_HOST,
-        virtual_host=settings.RABBIT_VHOST))
+        credentials=credentials,
+        host=settings.RABBIT_HOST,
+        port=settings.RABBIT_PORT,
+        virtual_host=settings.RABBIT_VHOST,
+        ssl=settings.RABBIT_TLS))
     channel = connection.channel()
     channel.queue_declare(queue=queue_name, durable=True)
 
@@ -219,7 +222,9 @@ class Worker(multiprocessing.Process):
         self.parameters = pika.ConnectionParameters(heartbeat_interval=5,
                                                     credentials=credentials,
                                                     host=settings.RABBIT_HOST,
-                                                    virtual_host=settings.RABBIT_VHOST)
+                                                    port=settings.RABBIT_PORT,
+                                                    virtual_host=settings.RABBIT_VHOST,
+                                                    ssl=settings.RABBIT_TLS)
         self.channel = None
         self.connection = None
 

--- a/queue/producer.py
+++ b/queue/producer.py
@@ -25,7 +25,9 @@ def push_to_queue(queue_name, qitem=None):
     parameters = pika.ConnectionParameters(heartbeat_interval=5,
                                            credentials=credentials,
                                            host=settings.RABBIT_HOST,
-                                           virtual_host=settings.RABBIT_VHOST)
+                                           port=settings.RABBIT_PORT,
+                                           virtual_host=settings.RABBIT_VHOST,
+                                           ssl=settings.RABBIT_TLS)
 
     retries = 0
     while True:

--- a/test_framework/integration_framework.py
+++ b/test_framework/integration_framework.py
@@ -99,7 +99,7 @@ logging.getLogger('requests').setLevel(logging.WARNING)
 
 
 class GraderStubBase(object):
-    """Abstract base class for external grader service stubs.  
+    """Abstract base class for external grader service stubs.
 
     We make this abstract to accommodate the two kinds of grading servers:
 
@@ -165,7 +165,9 @@ class GraderStubBase(object):
 
         params = pika.ConnectionParameters(credentials=creds,
                                            host=settings.RABBIT_HOST,
-                                           virtual_host=settings.RABBIT_VHOST)
+                                           port=settings.RABBIT_PORT,
+                                           virtual_host=settings.RABBIT_VHOST,
+                                           ssl=settings.RABBIT_TLS)
 
         connection = pika.BlockingConnection(parameters=params)
         channel = connection.channel()
@@ -312,7 +314,7 @@ class PassiveGraderStub(ForkingMixIn, HTTPServer, GraderStubBase):
     def start_workers(self, queue_name, num_workers=1):
         """Start workers that will forward submissions
         to the port the grader stub is listening on
-        
+
         `queue_name`: The name of the queue to pull messages from (string)
 
         `num_workers`: The number of workers to start for this queue (int)
@@ -349,13 +351,13 @@ class ActiveGraderStub(GraderStubBase):
 
         # Create a logged-in Django test client
         # to interact with the XQueue
-        XQueueTestClient.create_user(ActiveGraderStub.USERNAME, 
+        XQueueTestClient.create_user(ActiveGraderStub.USERNAME,
                                     ActiveGraderStub.USERNAME + '@edx.org',
                                     ActiveGraderStub.PASSWORD)
         self._client = XQueueTestClient(0)
         self._client.login(username=ActiveGraderStub.USERNAME,
                             password=ActiveGraderStub.PASSWORD)
-        
+
         # The polling thread will run until
         # this flag is set to False
         self._is_polling = True
@@ -399,7 +401,7 @@ class ActiveGraderStub(GraderStubBase):
         If it succeeds, it returns a `dict` of the submission info,
         which has keys `xqueue_header` and `xqueue_body`
         (and sometimes `xqueue_files` as well).
-        
+
         The `xqueue_header` is itself a JSON-decoded dict,
         but `xqueue_body` is a string.
 
@@ -420,7 +422,7 @@ class ActiveGraderStub(GraderStubBase):
 
         # Otherwise the response was successful
         else:
-            
+
             # JSON-decode the response
             response_dict = json.loads(response.content)
 
@@ -472,7 +474,7 @@ class ActiveGraderStub(GraderStubBase):
                 logger.warning('Could not submit response to XQueue: %s',
                                 response_dict['content'])
                 return False
-            
+
             # Otherwise, everything was successful
             else:
                 return True

--- a/xqueue/aws_settings.py
+++ b/xqueue/aws_settings.py
@@ -35,7 +35,9 @@ LOGGING = get_logger_config(LOG_DIR,
                             debug=False)
 
 RABBIT_HOST = ENV_TOKENS.get('RABBIT_HOST', RABBIT_HOST).encode('ascii')
+RABBIT_PORT = ENV_TOKENS.get('RABBIT_PORT', RABBIT_PORT)
 RABBIT_VHOST = ENV_TOKENS.get('RABBIT_VHOST', RABBIT_VHOST).encode('ascii')
+RABBIT_TLS = ENV_TOKENS.get('RABBIT_TLS', RABBIT_TLS)
 with open(ENV_ROOT / CONFIG_PREFIX + "auth.json") as auth_file:
     AUTH_TOKENS = json.load(auth_file)
 

--- a/xqueue/settings.py
+++ b/xqueue/settings.py
@@ -42,7 +42,9 @@ DATABASES = {
     }
 }
 RABBIT_HOST = 'localhost'
+RABBIT_PORT = 5672
 RABBIT_VHOST = '/'  # defaults to '/', otherwise a string
+RABBIT_TLS = False
 
 AWS_ACCESS_KEY_ID = "access_key_id"
 AWS_SECRET_ACCESS_KEY = "secret_access_key"

--- a/xqueue/test_settings.py
+++ b/xqueue/test_settings.py
@@ -67,7 +67,9 @@ except (IOError, ValueError):
 RABBITMQ_USER = ENV_TOKENS.get('RABBITMQ_USER', 'guest')
 RABBITMQ_PASS = ENV_TOKENS.get('RABBITMQ_PASS', 'guest')
 RABBIT_HOST = ENV_TOKENS.get('RABBIT_HOST', 'localhost')
+RABBIT_PORT = ENV_TOKENS.get('RABBIT_PORT', 5672)
 RABBIT_VHOST = ENV_TOKENS.get('RABBIT_VHOST', '/')
+RABBIT_TLS = ENV_TOKENS.get('RABBIT_TLS', False)
 # Mathworks setup
 # We load the Mathworks settings from envs.json
 # to avoid storing auth information in the repository


### PR DESCRIPTION
This allows for configuring xqueue to securely connect to an externally hosted RabbitMQ cluster.

See also: https://github.com/edx/configuration/pull/3447