### PR TITLE
Change edx-django-release-util version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ boto==2.39.0
 coverage==3.6b1
 django-nose==1.4.1
 dogstatsd-python==0.2
-edx-django-release-util==0.1.2
+edx-django-release-util==0.2.0
 gunicorn==0.16.1
 newrelic==2.64.0.48
 nose==1.2.1


### PR DESCRIPTION
Change the required version of edx-django-release-util to 0.2.0.

@edx-ops/pipeline-team Please review and tag appropriate parties.