### PR TITLE
Added management command to queue ungraded submissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ coverage.xml
 log
 nosetests.xml
 reports
+.idea/
+build/
+src/
+xqueue.sqlite

--- a/queue/management/commands/queue_ungraded_submissions.py
+++ b/queue/management/commands/queue_ungraded_submissions.py
@@ -1,0 +1,118 @@
+import logging
+
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from django.utils import timezone
+from datetime import datetime, timedelta
+import pprint
+
+from queue.models import Submission
+from queue.producer import push_to_queue
+
+log = logging.getLogger(__name__)
+
+
+def parse_iso_8601_string(iso_string):
+    return datetime.strptime(iso_string, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)
+
+
+class Command(BaseCommand):
+    help = "Push ungraded submissions onto the queue for grading. Useful for cases where grading fails."
+    ECHO_LIMIT = 25
+    ECHO_PROPERTIES = ('id', 'queue_name', 'push_time', 'pull_time', 'return_time', 'num_failures', 'lms_callback_url')
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--queues',
+            dest='queue_names',
+            default='',
+            help='Names of queues (comma-separated)',
+        )
+        parser.add_argument(
+            '--ids',
+            dest='submission_ids',
+            default='',
+            help='Submission.id values (comma-separated)',
+        )
+        parser.add_argument(
+            '--pull-time-start',
+            dest='pull_time_start',
+            default=None,
+            help='Submission pull_time range start (UTC, ISO-8601 formatted - 2017-01-01T00:00:00Z, et. al.)',
+        )
+        parser.add_argument(
+            '--pull-time-end',
+            dest='pull_time_end',
+            default=None,
+            help='Submission pull_time range end (UTC, ISO-8601 formatted - 2017-01-01T00:00:00Z, et. al.)',
+        )
+        parser.add_argument(
+            '--ignore-failures',
+            action='store_true',
+            dest='ignore_failures',
+            default=False,
+            help='Requeue the submissions even if their num_failures is greater than the max in settings',
+        )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            dest='dry_run',
+            default=False,
+            help='Echo the submissions that will be queued for grading (instead of actually queueing them)',
+        )
+
+    def handle(self, *args, **options):
+        grading_success_params = dict(
+            lms_ack=1,
+            retired=1
+        )
+        exclude_params = dict(pull_time=None)
+        filter_params = {}
+        if options['queue_names']:
+            filter_params['queue_name__in'] = options['queue_names'].split(',')
+        if options['submission_ids']:
+            filter_params['id__in'] = options['submission_ids'].split(',')
+        if options['pull_time_start']:
+            filter_params['pull_time__gte'] = parse_iso_8601_string(options['pull_time_start'])
+        if options['pull_time_end']:
+            filter_params['pull_time__lte'] = parse_iso_8601_string(options['pull_time_end'])
+        else:
+            filter_params['pull_time__lte'] = (
+                timezone.now() - timedelta(seconds=settings.PULLED_SUBMISSION_TIMEOUT)
+            )
+        if not options['ignore_failures']:
+            filter_params['num_failures__lt'] = settings.MAX_NUMBER_OF_FAILURES
+
+        submission_qset = (
+            Submission.objects
+            .filter(**filter_params)
+            .exclude(**grading_success_params)
+            .exclude(**exclude_params)
+            .order_by('-id')
+        )
+        if options['dry_run']:
+            pp = pprint.PrettyPrinter(indent=2)
+            for submission in submission_qset.values(*self.ECHO_PROPERTIES)[0:self.ECHO_LIMIT]:
+                self.stdout.write(pp.pformat(submission))
+            num_submissions = submission_qset.count()
+            self.stdout.write("\nMatching submission count: {0}".format(num_submissions))
+            if num_submissions > self.ECHO_LIMIT:
+                submission_ids = submission_qset.values_list('id', flat=True)
+                self.stdout.write("\nIDs: {0}\n\n".format(','.join(map(str, submission_ids))))
+        else:
+            self.requeue_submissions(submission_qset)
+
+    def requeue_submissions(self, submission_qset):
+        num_submissions = submission_qset.count()
+        if num_submissions == 0:
+            self.stdout.write("No matching submissions to queue.")
+            return
+        self.stdout.write("Queueing {0} submissions...".format(num_submissions))
+        for submission in submission_qset:
+            if submission.pull_time:
+                submission.num_failures += 1
+                submission.pull_time = None
+                submission.pullkey = ''
+                submission.save()
+            push_to_queue(submission.queue_name, str(submission.id))
+        self.stdout.write("Queueing finished")

--- a/queue/management/commands/tests/test_queue_ungraded_submissions.py
+++ b/queue/management/commands/tests/test_queue_ungraded_submissions.py
@@ -1,0 +1,147 @@
+import mock
+from datetime import timedelta
+from django.conf import settings
+from django.core.management import call_command
+from django.utils.six import StringIO
+from django.utils import timezone
+from django.test import TestCase
+from queue.models import Submission
+
+
+class TestQueueUngradedSubmissions(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.stdout = StringIO()
+        cls.default_pull_time = timezone.now() - timedelta(seconds=settings.PULLED_SUBMISSION_TIMEOUT * 2)
+        super(TestQueueUngradedSubmissions, cls).setUpClass()
+
+    def setUp(self):
+        self.mock_push_to_queue = mock.patch(
+            'queue.management.commands.queue_ungraded_submissions.push_to_queue'
+        ).start()
+
+    def tearDown(self):
+        self.mock_push_to_queue.stop()
+
+    def _create_submission(self, **create_params):
+        submission_params = dict(
+            xqueue_header=u'{}',
+            lms_ack=0,
+            retired=0,
+            pull_time=self.default_pull_time
+        )
+        submission_params.update(create_params)
+        return Submission.objects.create(**submission_params)
+
+    def _datetime_to_str(self, datetime_obj):
+        return datetime_obj.isoformat().replace('+00:00', 'Z')
+
+    def test_default_filters(self):
+        self._create_submission(lms_ack=1, retired=1),
+        self._create_submission(pull_time=None)
+        call_command(
+            'queue_ungraded_submissions',
+            stdout=self.stdout
+        )
+        self.mock_push_to_queue.assert_not_called()
+
+    def test_submission_id_param(self):
+        submissions = [self._create_submission(queue_name='some_queue') for _ in range(4)]
+        submissions_to_target = submissions[0:2]
+        call_command(
+            'queue_ungraded_submissions',
+            submission_ids=','.join([str(submission.id) for submission in submissions_to_target]),
+            stdout=self.stdout
+        )
+        self.assertEquals(self.mock_push_to_queue.call_count, len(submissions_to_target))
+        for submission in submissions_to_target:
+            self.mock_push_to_queue.assert_any_call('some_queue', str(submission.id))
+
+    def test_queue_names_param(self):
+        submissions = [
+            self._create_submission(queue_name=queue_name)
+            for queue_name in ['queue1', 'queue2', 'queue3', 'queue4']
+        ]
+        call_command(
+            'queue_ungraded_submissions',
+            queue_names='queue1,queue2',
+            stdout=self.stdout
+        )
+        self.assertEquals(self.mock_push_to_queue.call_count, 2)
+        self.mock_push_to_queue.assert_any_call('queue1', str(submissions[0].id))
+        self.mock_push_to_queue.assert_any_call('queue2', str(submissions[1].id))
+
+    def test_pull_time_params(self):
+        submission_pull_time_bounds = (
+            self.default_pull_time - timedelta(days=5),
+            self.default_pull_time - timedelta(days=3),
+        )
+        submission_pull_times = [
+            # Times within range
+            submission_pull_time_bounds[0],
+            submission_pull_time_bounds[0] + timedelta(minutes=30),
+            submission_pull_time_bounds[1],
+            # Times outside of range
+            submission_pull_time_bounds[0] - timedelta(days=1),
+            submission_pull_time_bounds[1] + timedelta(days=1),
+        ]
+        submissions = [
+            self._create_submission(queue_name='some_queue', pull_time=pull_time)
+            for pull_time in submission_pull_times
+        ]
+        call_command(
+            'queue_ungraded_submissions',
+            pull_time_start=self._datetime_to_str(submission_pull_time_bounds[0]),
+            pull_time_end=self._datetime_to_str(submission_pull_time_bounds[1]),
+            stdout=self.stdout
+        )
+        self.assertEquals(self.mock_push_to_queue.call_count, 3)
+        for submission in submissions[0:3]:
+            self.mock_push_to_queue.assert_any_call('some_queue', str(submission.id))
+
+    def test_ignore_failures_param(self):
+        submissions = [
+            self._create_submission(queue_name='some_queue', num_failures=num_failures)
+            for num_failures in [0, settings.MAX_NUMBER_OF_FAILURES]
+        ]
+        call_command(
+            'queue_ungraded_submissions',
+            '--ignore-failures',
+            stdout=self.stdout
+        )
+        self.assertEquals(self.mock_push_to_queue.call_count, 2)
+
+    def test_dry_run_param(self):
+        self._create_submission(queue_name='some_queue')
+        call_command(
+            'queue_ungraded_submissions',
+            '--dry-run',
+            stdout=self.stdout
+        )
+        self.mock_push_to_queue.assert_not_called()
+
+    def test_no_matching_submissions(self):
+        self._create_submission(queue_name='some_queue')
+        call_command(
+            'queue_ungraded_submissions',
+            queue_names='some_other_queue',
+            stdout=self.stdout
+        )
+        self.mock_push_to_queue.assert_not_called()
+
+    def test_submission_with_pull_time(self):
+        '''
+        Tests that a submission with a non-null pull_time value is updated when it's
+        resubmitted to the queue
+        '''
+        submission = self._create_submission(queue_name='some_queue')
+        self.assertEquals(submission.num_failures, 0)
+        self.assertIsNotNone(submission.pull_time)
+        call_command(
+            'queue_ungraded_submissions',
+            stdout=self.stdout
+        )
+        submission.refresh_from_db()
+        self.mock_push_to_queue.assert_called_once()
+        self.assertEquals(submission.num_failures, 1)
+        self.assertIsNone(submission.pull_time)


### PR DESCRIPTION
Run `python ./manage.py queue_ungraded_submissions --help` for usage details.

I'm with the MIT Office of Digital Learning and we've had some issues with coding problem submissions that fail at some point between being de-queued by xqueue-watcher and posting the graded result back to LMS. This management command should help us in a couple ways: (1) it can re-queue submissions that match various parameters, and (2) in the event of a grading failure, it can print submission data for debugging purposes