### PR TITLE
Close AMQP channel prior to closing connection in producer

### DIFF
--- a/queue/producer.py
+++ b/queue/producer.py
@@ -52,6 +52,7 @@ def push_to_queue(queue_name, qitem=None):
                               body=qitem,
                               properties=pika.BasicProperties(delivery_mode=2))
 
+    channel.close()
     connection.close()
     return queue.method.message_count
 


### PR DESCRIPTION
We were seeing many client disconnects on our RabbitMQ server with the warning `client unexpectedly closed TCP connection`.
This was traced back to xqueue closing the TCP connection before the AMQP channels were closed.
This patch introduces a call to channel.close() to prevent this warning.