### PR TITLE
PLAT-1852 Switch to pytest, improve test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,21 @@
+[run]
+data_file = .coverage
+source =
+    queue
+omit =
+    queue/management/commands/tests/*
+    queue/migrations/*
+    queue/tests/*
+
+[report]
+exclude_lines =
+   pragma: no cover
+   raise NotImplementedError
+ignore_errors = True
+
+[html]
+directory = reports/cover
+title = XQueue Python Test Coverage Report
+
+[xml]
+output = coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.pyc
+.DS_Store
+.cache/
 .coverage
 cover_html
 coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.7"
 install:
-  - pip install coveralls pep8 rednose
+  - pip install coveralls pep8
   - pip install -r pre-requirements.txt
   - pip install -r requirements.txt
 services:

--- a/queue/management/commands/tests/test_push_orphaned_submissions.py
+++ b/queue/management/commands/tests/test_push_orphaned_submissions.py
@@ -1,0 +1,24 @@
+"""
+Tests of the push_orphaned_submissions management command.
+"""
+from __future__ import absolute_import
+
+import mock
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class TestPushOrphanedSubmissions(TestCase):
+    """
+    Tests of the push_orphaned_submissions management command.
+    """
+    def test_no_queue_names(self):
+        path = 'queue.management.commands.push_orphaned_submissions.Command.push_orphaned_submissions'
+        with mock.patch(path) as mock_method:
+            call_command(u'push_orphaned_submissions')
+            assert mock_method.call_count == 0
+
+    def test_empty_queue(self):
+        with mock.patch('queue.management.commands.push_orphaned_submissions._http_post') as mock_function:
+            call_command(u'push_orphaned_submissions', u'empty')
+            assert mock_function.call_count == 0

--- a/queue/management/commands/tests/test_requeue_pulled_submissions.py
+++ b/queue/management/commands/tests/test_requeue_pulled_submissions.py
@@ -1,0 +1,19 @@
+"""
+Tests of the requeue_pulled_submissions management command.
+"""
+from __future__ import absolute_import
+
+import mock
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class TestRequeuePulledSubmissions(TestCase):
+    """
+    Tests of the requeue_pulled_submissions management command.
+    """
+    def test_all_queues(self):
+        path = 'queue.management.commands.requeue_pulled_submissions.Command.requeue_submissions'
+        with mock.patch(path) as mock_method:
+            call_command(u'requeue_pulled_submissions')
+            assert mock_method.call_count == 1

--- a/queue/management/commands/tests/test_retire_submissions.py
+++ b/queue/management/commands/tests/test_retire_submissions.py
@@ -1,0 +1,19 @@
+"""
+Tests of the retire_submissions management command.
+"""
+from __future__ import absolute_import
+
+import mock
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class TestRetireSubmissions(TestCase):
+    """
+    Tests of the retire_submissions management command.
+    """
+    def test_all_queues(self):
+        path = 'queue.management.commands.retire_submissions.Command.retire_submissions'
+        with mock.patch(path) as mock_method:
+            call_command(u'retire_submissions', force=True)
+            assert mock_method.call_count == 1

--- a/queue/management/commands/tests/test_update_users.py
+++ b/queue/management/commands/tests/test_update_users.py
@@ -1,0 +1,31 @@
+"""
+Tests of the update_users management command.
+"""
+from __future__ import absolute_import
+
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class TestUpdateUsers(TestCase):
+    """
+    Tests of the update_users management command.
+    """
+    def test_existing_user(self):
+        assert User.objects.count() == 0
+        user = User.objects.create_user(username=u'test_user')
+        assert not user.has_usable_password()
+        call_command(u'update_users')
+        users = User.objects.all()
+        assert len(users) == 1
+        user = users[0]
+        assert user.username == u'test_user'
+        assert user.has_usable_password()
+
+    def test_new_user(self):
+        assert User.objects.count() == 0
+        call_command(u'update_users')
+        users = User.objects.all()
+        assert len(users) == 1
+        assert users[0].username == u'test_user'

--- a/queue/tests/test_matlab_grader.py
+++ b/queue/tests/test_matlab_grader.py
@@ -1,17 +1,16 @@
 """Test that the XQueue responds to a client."""
-from test_framework.integration_framework import PassiveGraderStub, \
-    GradeResponseListener, XQueueTestClient
-
+import pytest
 from django.test import TransactionTestCase
 from django.conf import settings
 from django.test.utils import override_settings
 from uuid import uuid4
 from textwrap import dedent
-from nose.plugins.attrib import attr
-from nose.plugins.skip import SkipTest
+
+from test_framework.integration_framework import PassiveGraderStub, \
+    GradeResponseListener, XQueueTestClient
 
 
-@attr('grader_integration')
+@pytest.mark.grader_integration
 class MatlabGraderTest(TransactionTestCase):
     """Test that we can send messages to the xqueue
     and receive a response from a Mathworks server
@@ -38,7 +37,7 @@ class MatlabGraderTest(TransactionTestCase):
 
         # Skip if the settings are missing
         if self.api_key is None or self.grader_url is None:
-            raise SkipTest('You must specify an API key and URL for Mathworks in test_env.json')
+            pytest.skip('You must specify an API key and URL for Mathworks in test_env.json')
 
         # Create the response listener
         # which listens for responses on an open port

--- a/queue/tests/test_models.py
+++ b/queue/tests/test_models.py
@@ -1,0 +1,22 @@
+"""
+Tests of the database models in the ``queue`` application.
+"""
+from __future__ import absolute_import
+
+from django.test import TestCase
+
+from queue.models import Submission
+
+
+class TestSubmission(TestCase):
+    """
+    Tests of the ``Submission`` model.
+    """
+    def test_keys(self):
+        keys = u'Alabama Florida Ohio Oklahoma West Virginia'
+        submission = Submission(s3_keys=keys)
+        assert submission.keys == keys
+
+    def test_text_representation(self):
+        submission = Submission(requester_id=u'Alice', queue_name=u'Wonderland', xqueue_header=u'{}')
+        assert u"Submission from Alice for queue 'Wonderland'" in unicode(submission)

--- a/queue/tests/test_run_consumer.py
+++ b/queue/tests/test_run_consumer.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_raises, assert_equals
+import pytest
 from itertools import combinations
 
 from queue.management.commands.run_consumer import assign_workers_to_queues, assign_queues_to_workers, NoAssignmentError
@@ -15,12 +15,14 @@ def test_assign_workers_to_queues():
     assert min_disjoint_workers(assign_workers_to_queues("ABC", 4, 3, 1)) >= 1
 
     # Fewer workers than queues -> can't make single assignments distinct
-    assert_raises(NoAssignmentError, assign_workers_to_queues, "ABC", 2, 1, 1)
+    with pytest.raises(NoAssignmentError):
+        assign_workers_to_queues("ABC", 2, 1, 1)
 
     # A -> 0, 1
     # B -> 0, 1
     # C -> 0, 1
-    assert_raises(NoAssignmentError, assign_workers_to_queues, "ABC", 2, 2, 1)
+    with pytest.raises(NoAssignmentError):
+        assign_workers_to_queues("ABC", 2, 2, 1)
 
     # A -> 0, 1
     # B -> 0, 2
@@ -28,7 +30,8 @@ def test_assign_workers_to_queues():
     assert min_disjoint_workers(assign_workers_to_queues("ABC", 3, 2, 1)) >= 1
 
     # Based on prod settings
-    assert_raises(NoAssignmentError, assign_workers_to_queues, range(8), 24, 12, 7)
+    with pytest.raises(NoAssignmentError):
+        assign_workers_to_queues(range(8), 24, 12, 7)
     assert min_disjoint_workers(assign_workers_to_queues(range(8), 24, 12, 6)) >= 6
     assert min_disjoint_workers(assign_workers_to_queues(range(8), 24, 12, 4)) >= 4
     assert min_disjoint_workers(assign_workers_to_queues(range(8), 24, 12, 3)) >= 3
@@ -37,17 +40,10 @@ def test_assign_workers_to_queues():
 
 
 def test_assign_queues_to_workers():
-    assert_equals(
-        [set("A"), set("B")],
-        assign_queues_to_workers(2, {"A": [0], "B": [1]})
-    )
+    assert [set("A"), set("B")] == assign_queues_to_workers(2, {"A": [0], "B": [1]})
 
-    assert_equals(
-        [set("A"), set("B"), set("A"), set("B"), set("B")],
-        assign_queues_to_workers(5, {"A": [0, 2], "B": [1, 3, 4]})
-    )
+    assert [set("A"), set("B"), set("A"), set("B"), set("B")] == assign_queues_to_workers(
+        5, {"A": [0, 2], "B": [1, 3, 4]})
 
-    assert_equals(
-        [set("AB"), set("ABC"), set("AC"), set("BC")],
-        assign_queues_to_workers(4, {"A": [0, 1, 2], "B": [0, 1, 3], "C": [1, 2 , 3]})
-    )
+    assert [set("AB"), set("ABC"), set("AC"), set("BC")] == assign_queues_to_workers(
+        4, {"A": [0, 1, 2], "B": [0, 1, 3], "C": [1, 2, 3]})

--- a/rakefile
+++ b/rakefile
@@ -46,7 +46,9 @@ end
 
 desc "Run all tests"
 task :test => REPORT_DIR do
-    ENV['NOSE_XUNIT_FILE'] = File.join(REPORT_DIR, "nosetests.xml")
-    ENV['NOSE_COVER_HTML_DIR'] = File.join(REPORT_DIR, "cover")
-    sh("python manage.py test --settings xqueue.test_settings --noinput")
+    COVERAGERC = File.join(REPO_ROOT, ".coveragerc")
+    XUNIT_FILE = File.join(REPORT_DIR, "nosetests.xml")
+    sh("python -Wd -m pytest --cov --cov-report term-missing --ds=xqueue.test_settings --junitxml=#{XUNIT_FILE} queue")
+    sh("coverage html --rcfile=#{COVERAGERC}")
+    sh("coverage xml --rcfile=#{COVERAGERC}")
 end

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,21 @@
 django>=1.8,<1.9
 MySQL-python==1.2.5
 argparse==1.2.1
+attrs==17.4.0
 boto==2.39.0
-coverage==3.6b1
-django-nose==1.4.1
+coverage==4.4.2
 dogstatsd-python==0.2
 edx-django-release-util==0.3.0
 gunicorn==0.16.1
 newrelic==2.98.0.81
-nose==1.2.1
-nosexcover==1.0.7
 path.py==2.4.1
 -e git+https://github.com/pika/pika.git@a731347fc0#egg=pika
+pluggy==0.6.0
+py==1.5.2
+pytest==3.3.2
+pytest-cov==2.5.1
+pytest-django==3.1.2
 python-termstyle==0.1.10
-rednose==0.3
 requests==0.14.2
 wsgiref==0.1.2
 mock==2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist = py{27}-django{18,19,110,111}
+
+[pytest]
+DJANGO_SETTINGS_MODULE = xqueue.test_settings
+addopts = --nomigrations --reuse-db --durations=20
+filterwarnings = default
+norecursedirs = .* jenkins load_tests log reports script test_framework xqueue
+
+[testenv]
+deps =
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2.0
+    -rrequirements.txt
+passenv =
+    TRAVIS*
+commands =
+    {posargs:rake test}

--- a/xqueue/test_auth.json
+++ b/xqueue/test_auth.json
@@ -1,0 +1,5 @@
+{
+  "USERS": {
+    "test_user": "password"
+  }
+}

--- a/xqueue/test_settings.py
+++ b/xqueue/test_settings.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from settings import *
 from logsettings import get_logger_config
 import os
@@ -9,8 +11,8 @@ log_dir = REPO_PATH / "log"
 
 try:
     os.makedirs(log_dir)
-except:
-    pass
+except Exception as e:
+    print(e)
 
 LOGGING = get_logger_config(log_dir,
                             logging_env="test",
@@ -85,11 +87,6 @@ MATHWORKS_API_KEY = ENV_TOKENS.get('MATHWORKS_API_KEY', None)
 TEST_XQUEUE_NAME = 'test_queue_%s' % uuid4().hex
 XQUEUES[TEST_XQUEUE_NAME] = 'http://127.0.0.1:12348'
 
-# Nose Test Runner
-INSTALLED_APPS += ('django_nose',)
-NOSE_ARGS = ['--cover-erase', '--with-xunit', '--with-xcoverage',
-             '--cover-html',
-             '--cover-inclusive', '--cover-html-dir',
-             os.environ.get('NOSE_COVER_HTML_DIR', 'cover_html'),
-             '--cover-package', 'queue', 'queue']
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+# Configuration for testing the update_users management command
+ENV_ROOT = ROOT_PATH
+CONFIG_PREFIX = 'test_'


### PR DESCRIPTION
Switched from nose to pytest because nose wasn't correctly catching the initialization of models.py in coverage data (and because we're standardizing on pytest for assorted other reasons).  Also added an assortment of new tests that increase coverage from 65% to 74%.

The Django dependency will need to be broken out of requirements.txt for the tox configuration to work as intended, but that should probably be part of a larger requirements handing cleanup.  I'm just checking `tox.ini` in now because it's an appropriate place to store the pytest configuration.