### PR TITLE
Use a configurable session engine.

### DIFF
--- a/pre-requirements.txt
+++ b/pre-requirements.txt
@@ -1,1 +1,1 @@
-setuptools==15.2
+setuptools==28.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ idna==2.6                 # via requests
 mysql-python==1.2.5
 newrelic==2.106.1.88
 path.py==2.4.1
+python-memcached==1.48
 python-termstyle==0.1.10
 pytz==2018.3
 pyyaml==3.12              # via edx-django-release-util

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -10,6 +10,7 @@ gunicorn==0.16.1
 newrelic
 path.py==2.4.1
 -e git+https://github.com/pika/pika.git@a731347fc0#egg=pika
+python-memcached==1.48
 python-termstyle==0.1.10
 pytz
 requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -29,6 +29,7 @@ pycodestyle==2.3.1
 pytest-cov==2.5.1
 pytest-django==3.1.2
 pytest==3.4.2
+python-memcached==1.48
 python-termstyle==0.1.10
 pytz==2018.3
 pyyaml==3.12              # via edx-django-release-util

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -26,6 +26,7 @@ py==1.5.2                 # via pytest
 pytest-cov==2.5.1
 pytest-django==3.1.2
 pytest==3.4.2
+python-memcached==1.48
 python-termstyle==0.1.10
 pytz==2018.3
 pyyaml==3.12              # via edx-django-release-util

--- a/xqueue/aws_settings.py
+++ b/xqueue/aws_settings.py
@@ -1,6 +1,7 @@
 from settings import *
 import json
 from logsettings import get_logger_config
+from django.conf import global_settings
 
 with open(ENV_ROOT / "xqueue.env.json") as env_file:
     ENV_TOKENS = json.load(env_file)
@@ -62,3 +63,8 @@ DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 AWS_STORAGE_BUCKET_NAME = UPLOAD_BUCKET
 AWS_LOCATION = UPLOAD_PATH_PREFIX
 AWS_QUERYSTRING_EXPIRE = ENV_TOKENS.get('UPLOAD_URL_EXPIRE', UPLOAD_URL_EXPIRE)
+
+# Use session engine settings from env
+SESSION_ENGINE = ENV_TOKENS.get('SESSION_ENGINE', global_settings.SESSION_ENGINE)
+# Use a custom cache setting from env; useful if, for example, the session engine uses cache and requires Memcached
+CACHES = ENV_TOKENS.get('CACHES', global_settings.CACHES)

--- a/xqueue/aws_settings.py
+++ b/xqueue/aws_settings.py
@@ -65,6 +65,6 @@ AWS_LOCATION = UPLOAD_PATH_PREFIX
 AWS_QUERYSTRING_EXPIRE = ENV_TOKENS.get('UPLOAD_URL_EXPIRE', UPLOAD_URL_EXPIRE)
 
 # Use session engine settings from env
-SESSION_ENGINE = ENV_TOKENS.get('SESSION_ENGINE', global_settings.SESSION_ENGINE)
+SESSION_ENGINE = ENV_TOKENS.get('SESSION_ENGINE') or global_settings.SESSION_ENGINE
 # Use a custom cache setting from env; useful if, for example, the session engine uses cache and requires Memcached
-CACHES = ENV_TOKENS.get('CACHES', global_settings.CACHES)
+CACHES = ENV_TOKENS.get('CACHES') or global_settings.CACHES


### PR DESCRIPTION
Storing xqueue sessions in the DB can be problematic for some setups. Make it configurable so it can be stored in the cache, for example.

Complementary configuration PR at https://github.com/edx/configuration/pull/4313.