### PR TITLE
PLAT-1853 Support Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ matrix:
     - python: 2.7
       env: TOXENV=py27-django18
     - python: 2.7
+      env: TOXENV=py27-django19
+    - python: 2.7
+      env: TOXENV=py27-django110
+    - python: 2.7
+      env: TOXENV=py27-django111
+    - python: 2.7
       env: TOXENV=quality
 install:
   - pip install -r requirements/travis.txt

--- a/queue/lms_interface.py
+++ b/queue/lms_interface.py
@@ -78,8 +78,8 @@ def submit(request):
                                         queue_name=queue_name,
                                         xqueue_header=xqueue_header,
                                         xqueue_body=xqueue_body,
-                                        urls=urls_json,
-                                        keys=keys_json)
+                                        s3_urls=urls_json,
+                                        s3_keys=keys_json)
                 submission.save()
                 transaction.commit()  # Explicit commit to DB before inserting submission.id into queue
 

--- a/queue/management/commands/push_orphaned_submissions.py
+++ b/queue/management/commands/push_orphaned_submissions.py
@@ -12,13 +12,15 @@ log = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    args = "<queue_name>"
     help = "Push orphaned submissions to the external grader"
+
+    def add_arguments(self, parser):
+        parser.add_argument('queue_name', nargs='+')
 
     def handle(self, *args, **options):
         log.info(' [*] Pushing orphaned submission to the external grader...')
 
-        for queue_name in args:
+        for queue_name in options['queue_name']:
             orphaned_submissions = Submission.objects.filter(queue_name=queue_name, push_time=None, return_time=None, retired=False)
             self.push_orphaned_submissions(orphaned_submissions)
 

--- a/queue/management/commands/requeue_pulled_submissions.py
+++ b/queue/management/commands/requeue_pulled_submissions.py
@@ -11,18 +11,21 @@ log = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    args = "<queue_name>"
     help = "Process currently pulled submissions, and requeue if external grader has not replied in settings.PULLED_SUBMISSION_TIMEOUT seconds. Optional list of <queue_name>s"
+
+    def add_arguments(self, parser):
+        parser.add_argument('queue_name', nargs='*')
 
     def handle(self, *args, **options):
         log.info(' [*] Running requeue of pulled submissions...')
 
-        if len(args) == 0:
+        queue_names = options['queue_name']
+        if len(queue_names) == 0:
             open_submissions = Submission.objects.filter(retired=False)
             open_submissions = open_submissions.exclude(pull_time=None)
             self.requeue_submissions(open_submissions)
         else:
-            for queue_name in args:
+            for queue_name in queue_names:
                 open_submissions = Submission.objects.filter(queue_name=queue_name, retired=False)
                 open_submissions = open_submissions.exclude(pull_time=None)
                 self.requeue_submissions(open_submissions)

--- a/queue/management/commands/run_consumer.py
+++ b/queue/management/commands/run_consumer.py
@@ -63,10 +63,9 @@ def assign_queues_to_workers(num_workers, queue_assignments):
 
 
 class Command(BaseCommand):
-    args = "<worker count>"
     help = """
     Listens to all queues specified as being push-queues in the django
-    configuration with <worker count> processes
+    configuration
     """
 
     def handle(self, *args, **options):
@@ -92,7 +91,6 @@ class Command(BaseCommand):
             time.sleep(MONITOR_SLEEPTIME)
 
         log.info(' [*] All workers finished. Exiting')
-
 
     def monitor(self, workers):
         finished_workers = []

--- a/queue/management/commands/tests/test_push_orphaned_submissions.py
+++ b/queue/management/commands/tests/test_push_orphaned_submissions.py
@@ -4,7 +4,8 @@ Tests of the push_orphaned_submissions management command.
 from __future__ import absolute_import
 
 import mock
-from django.core.management import call_command
+import pytest
+from django.core.management import CommandError, call_command
 from django.test import TestCase
 
 
@@ -13,10 +14,8 @@ class TestPushOrphanedSubmissions(TestCase):
     Tests of the push_orphaned_submissions management command.
     """
     def test_no_queue_names(self):
-        path = 'queue.management.commands.push_orphaned_submissions.Command.push_orphaned_submissions'
-        with mock.patch(path) as mock_method:
+        with pytest.raises(CommandError, message='Error: too few arguments'):
             call_command(u'push_orphaned_submissions')
-            assert mock_method.call_count == 0
 
     def test_empty_queue(self):
         with mock.patch('queue.management.commands.push_orphaned_submissions._http_post') as mock_function:

--- a/queue/tests/test_lms_interface.py
+++ b/queue/tests/test_lms_interface.py
@@ -9,7 +9,7 @@ from django.contrib.auth.models import User
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.test.client import Client
-from django.test import SimpleTestCase, override_settings
+from django.test import TransactionTestCase, override_settings
 
 from queue import lms_interface
 from queue.models import Submission
@@ -22,7 +22,7 @@ def parse_xreply(xreply):
 
 
 @override_settings(XQUEUES={'tmp': None})
-class lms_interface_test(SimpleTestCase):
+class TestLMSInterface(TransactionTestCase):
 
     def setUp(self):
         self.credentials = {'username': 'LMS', 'password': 'CambridgeMA'}

--- a/queue/urls.py
+++ b/queue/urls.py
@@ -1,23 +1,27 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
+
+from queue.ext_interface import get_queuelen, get_submission, put_result
+from queue.lms_interface import submit
+from queue.views import log_in, log_out, status
 
 # General
-#------------------------------------------------------------
-urlpatterns = patterns('queue.views',
-    url(r'^login/$', 'log_in'),
-    url(r'^logout/$', 'log_out'),
-    url(r'^status/$', 'status'),
-)
+# ------------------------------------------------------------
+urlpatterns = [
+    url(r'^login/$', log_in),
+    url(r'^logout/$', log_out),
+    url(r'^status/$', status),
+]
 
 # LMS-facing interface for queue requests
-#------------------------------------------------------------
-urlpatterns += patterns('queue.lms_interface',
-    url(r'^submit/$', 'submit'),
-)
+# ------------------------------------------------------------
+urlpatterns += [
+    url(r'^submit/$', submit),
+]
 
 # External pulling interface
-#------------------------------------------------------------
-urlpatterns += patterns('queue.ext_interface',
-    url(r'^get_queuelen/$', 'get_queuelen'),
-    url(r'^get_submission/$', 'get_submission'),
-    url(r'^put_result/$', 'put_result'),
-)
+# ------------------------------------------------------------
+urlpatterns += [
+    url(r'^get_queuelen/$', get_queuelen),
+    url(r'^get_submission/$', get_submission),
+    url(r'^put_result/$', put_result),
+]

--- a/xqueue/urls.py
+++ b/xqueue/urls.py
@@ -1,5 +1,5 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^xqueue/', include('queue.urls')),
-)
+]


### PR DESCRIPTION
Support and test Django 1.9, 1.10, and 1.11:

* Fixed URL configuration to work with the deprecation removals in 1.10
* Switched management commands from optparse to argparse
* Fixed a query to use the actual field names instead of property aliases for them
* Used the correct `TestCase` subclass for some tests involving manual transaction commits
* Test each Django version in Travis