### PR TITLE
auto_now changes arrival on every update

### DIFF
--- a/queue/migrations/0002_stop_updating_arrival_time.py
+++ b/queue/migrations/0002_stop_updating_arrival_time.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('queue', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='submission',
+            name='arrival_time',
+            field=models.DateTimeField(auto_now_add=True),
+        ),
+    ]

--- a/queue/models.py
+++ b/queue/models.py
@@ -28,7 +28,7 @@ class Submission(models.Model):
     s3_urls = models.CharField(max_length=CHARFIELD_LEN_LARGE) # urls for external access
 
     # Timing
-    arrival_time = models.DateTimeField(auto_now=True)         # Time of arrival from LMS
+    arrival_time = models.DateTimeField(auto_now_add=True)     # Time of arrival from LMS
     pull_time    = models.DateTimeField(null=True, blank=True) # Time of pull request, if pulled from external grader
     push_time    = models.DateTimeField(null=True, blank=True) # Time of push, if xqueue pushed to external grader
     return_time  = models.DateTimeField(null=True, blank=True) # Time of return from external grader


### PR DESCRIPTION
This isn't what this field is documented to do, so switch it to only set on creation.

I checked with sqlmigrate - this will not generate any ALTER TABLE, it's just used by django to set or change this field.