### PR TITLE
Upgrade some versions - remove pre-requirements

### DIFF
--- a/pre-requirements.txt
+++ b/pre-requirements.txt
@@ -1,1 +1,0 @@
-setuptools==28.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,13 +11,13 @@ chardet==3.0.4            # via requests
 django-storages-redux==1.3.1
 django==1.8.19
 dogstatsd-python==0.2
-edx-django-release-util==0.3.0
+edx-django-release-util==0.3.1
 futures==3.2.0            # via isort
 gunicorn==0.16.1
 idna==2.6                 # via requests
 isort==4.3.4
 mysql-python==1.2.5
-newrelic==2.106.1.88
+newrelic==3.0.0.89
 path.py==2.4.1
 python-memcached==1.48
 python-termstyle==0.1.10

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,7 +5,7 @@ boto==2.39.0
 django>=1.8,<1.9
 django-storages-redux==1.3.1
 dogstatsd-python==0.2
-edx-django-release-util==0.3.0
+edx-django-release-util==0.3.1
 gunicorn==0.16.1
 isort
 newrelic

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,7 +14,7 @@ coverage==4.5.1           # via codecov, pytest-cov
 django-storages-redux==1.3.1
 django==1.8.19
 dogstatsd-python==0.2
-edx-django-release-util==0.3.0
+edx-django-release-util==0.3.1
 funcsigs==1.0.2           # via mock, pytest
 futures==3.2.0            # via isort
 gunicorn==0.16.1
@@ -22,7 +22,7 @@ idna==2.6                 # via requests
 isort==4.3.4
 mock==2.0.0
 mysql-python==1.2.5
-newrelic==2.106.1.88
+newrelic==3.0.0.89
 path.py==2.4.1
 pbr==3.1.1                # via mock
 pluggy==0.6.0             # via pytest, tox

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 coverage==4.5.1           # via pytest-cov
 django-storages-redux==1.3.1
 dogstatsd-python==0.2
-edx-django-release-util==0.3.0
+edx-django-release-util==0.3.1
 funcsigs==1.0.2           # via mock, pytest
 futures==3.2.0            # via isort
 gunicorn==0.16.1
@@ -20,7 +20,7 @@ idna==2.6                 # via requests
 isort==4.3.4
 mock==2.0.0
 mysql-python==1.2.5
-newrelic==2.106.1.88
+newrelic==3.0.0.89
 path.py==2.4.1
 pbr==3.1.1                # via mock
 pluggy==0.6.0             # via pytest


### PR DESCRIPTION
This relies on testing on https://github.com/edx/configuration/pull/4391 which is what used to install pre-requirements.txt (all other use cases just rely on the setuptools being used in the venv setup)