### PR TITLE
Remove a hardcoded assumption of SERVICE_VARIANT

### DIFF
--- a/queue/management/commands/update_users.py
+++ b/queue/management/commands/update_users.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
 
         log.info("root is : " + settings.ENV_ROOT)
-        auth_filename = '{0}auth.json'.format(settings.CONFIG_PREFIX)
+        auth_filename = getattr(settings,'AUTH_FILENAME','xqueue.auth.json')
         auth_path = os.path.join(settings.ENV_ROOT, auth_filename)
 
         log.info(' [*] reading {0}'.format(auth_path))

--- a/xqueue/aws_settings.py
+++ b/xqueue/aws_settings.py
@@ -2,12 +2,7 @@ from settings import *
 import json
 from logsettings import get_logger_config
 
-# Allow to specify a prefix for env/auth configuration files
-SERVICE_VARIANT = os.environ.get('SERVICE_VARIANT', '')
-if SERVICE_VARIANT:
-    CONFIG_PREFIX = SERVICE_VARIANT + "."
-
-with open(ENV_ROOT / CONFIG_PREFIX + "env.json") as env_file:
+with open(ENV_ROOT / "xqueue.env.json") as env_file:
     ENV_TOKENS = json.load(env_file)
 
 XQUEUES = ENV_TOKENS['XQUEUES']
@@ -30,7 +25,7 @@ LOGGING = get_logger_config(LOG_DIR,
 
 RABBIT_HOST = ENV_TOKENS.get('RABBIT_HOST', RABBIT_HOST).encode('ascii')
 RABBIT_VHOST = ENV_TOKENS.get('RABBIT_VHOST', RABBIT_VHOST).encode('ascii')
-with open(ENV_ROOT / CONFIG_PREFIX + "auth.json") as auth_file:
+with open(ENV_ROOT / "xqueue.auth.json") as auth_file:
     AUTH_TOKENS = json.load(auth_file)
 
 DATABASES = AUTH_TOKENS['DATABASES']

--- a/xqueue/logsettings.py
+++ b/xqueue/logsettings.py
@@ -10,8 +10,7 @@ def get_logger_config(log_dir,
                       dev_env=False,
                       syslog_addr=None,
                       debug=False,
-                      local_loglevel='INFO',
-                      service_variant='xqueue'):
+                      local_loglevel='INFO'):
 
     """
 
@@ -33,11 +32,9 @@ def get_logger_config(log_dir,
         local_loglevel = 'INFO'
 
     hostname = platform.node().split(".")[0]
-    syslog_format = ("[service_variant={service_variant}]"
-                     "[%(name)s][env:{logging_env}] %(levelname)s "
+    syslog_format = ("[%(name)s][env:{logging_env}] %(levelname)s "
                      "[{hostname}  %(process)d] [%(filename)s:%(lineno)d] "
                      "- %(message)s").format(
-                        service_variant=service_variant,
                         logging_env=logging_env, hostname=hostname)
 
     handlers = ['console', 'local'] if debug else ['local']

--- a/xqueue/test_settings.py
+++ b/xqueue/test_settings.py
@@ -91,3 +91,6 @@ NOSE_ARGS = ['--cover-erase', '--with-xunit', '--with-xcoverage',
              os.environ.get('NOSE_COVER_HTML_DIR', 'cover_html'),
              '--cover-package', 'queue', 'queue']
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+# Configuration for testing the update_users management command
+ENV_ROOT = ROOT_PATH
+AUTH_FILENAME = 'test_auth.json'


### PR DESCRIPTION
This is a cherry pick of code on master to deal with the fact that configuration's master no longer pushes in SERVICE_VARIANT
We'll be on master later this week, but may as well deploy this xqueue now.

Without this, we can't provision the xqueue
We no longer define CONFIG_PREFIX in devstack.py, so remove the
use of it.

Stop relying on SERVICE_VARIANT

Remove the service_variant syslog prefix