### PR TITLE
It's very slow to query on these 4 columns

### DIFF
--- a/queue/migrations/0003_compound_indexes.py
+++ b/queue/migrations/0003_compound_indexes.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('queue', '0002_stop_updating_arrival_time'),
+    ]
+
+    operations = [
+        migrations.AlterIndexTogether(
+            name='submission',
+            index_together=set([('queue_name', 'retired', 'pull_time', 'arrival_time'), ('lms_callback_url', 'retired'), ('queue_name', 'retired', 'push_time', 'arrival_time')]),
+        ),
+    ]

--- a/queue/models.py
+++ b/queue/models.py
@@ -16,6 +16,14 @@ class Submission(models.Model):
     '''
     Representation of submission request, including metadata information
     '''
+
+    class Meta(object):
+        # Once we get to Django 1.11 use indexes, it would have allowed a better index name
+        # https://docs.djangoproject.com/en/1.11/ref/models/options/#django.db.models.Options.indexes
+        index_together = [('queue_name', 'retired', 'push_time', 'arrival_time'),
+                          ('queue_name', 'retired', 'pull_time', 'arrival_time'),
+                          ('lms_callback_url', 'retired')]
+
     # Submission
     requester_id     = models.CharField(max_length=CHARFIELD_LEN_SMALL) # ID of LMS
     lms_callback_url = models.CharField(max_length=CHARFIELD_LEN_SMALL, db_index=True)


### PR DESCRIPTION
Build compound queries, previously we only had indexes on retired,
lms_callback_url and queue_name so queries would need to search all
submissions for a given queue or retired submissions, both of which
could be huge (and take minutes to query).  This should improve that.