### PR TITLE
We truncate during setting this field but not for searches

### DIFF
--- a/queue/lms_interface.py
+++ b/queue/lms_interface.py
@@ -93,7 +93,7 @@ def _invalidate_prior_submissions(lms_callback_url):
         (user, module-id). This function relies on the fact that lms_callback_url
         takes the form: /path/to/callback/<user>/<id>/...
     '''
-    prior_submissions = Submission.objects.filter(lms_callback_url=lms_callback_url, retired=False)
+    prior_submissions = Submission.objects.filter(lms_callback_url=lms_callback_url[:128], retired=False)
     prior_submissions.update(retired=True)
 
 


### PR DESCRIPTION
Mysql is never going to match long_url vs truncated_url

Of course, there's always a good chance we're going to submit two
duplicate callback urls, for the same user but different blocks.  Hope
not.  Different bug, that's been broken since the XQueue was designed.

This completes the work started in
https://github.com/edx/xqueue/pull/100
I think we'd have been better off avoiding the migration we declined in https://github.com/edx/xqueue/pull/99 by hashing the URL down so that it fits in 128 characters.  I may fix it by migrating the
table, this at least will work more than it has in years.