### PR TITLE
Pin pip version to 9.0.3

### DIFF
--- a/pre-requirements.txt
+++ b/pre-requirements.txt
@@ -1,1 +1,2 @@
 setuptools==15.2
+pip==9.0.3


### PR DESCRIPTION
For Ginkgo deployments, we have seen a couple of sandboxes fail because they ended up with [pip 10 beta](https://github.com/pypa/pip/releases/tag/10.0.0b1) installed. This breaks the [installation of pika from git|https://github.com/edx/xqueue/blob/3b2469c881a76cf5f095def21f87eafe005b5653/requirements.txt#L14], possibly due to a bug in the beta release. With this PR we hope to pin the version of pip to 9.0.3 (the latest 9.x release) similar to how it's pinned for [edx-platform](https://github.com/edx/edx-platform/blob/4841ff7943d397b409b6eae21b4085342e23af08/requirements/edx/pre.txt#L10). 

**JIRA tickets**: OSPR-2330

**Sandbox URL**: NA

**Merge deadline**: None

**Testing instructions**:

* Deploy sandbox based on this branch. 
* The xqueue virtualenv should have pip 9 instead of pip 10

**Reviewers**
- [ ] @rocioar
- [ ] edX reviewer[s] TBD
