### PR TITLE
Add a delete_old_submissions management command

### DIFF
--- a/.travis/docker-compose-travis.yml
+++ b/.travis/docker-compose-travis.yml
@@ -1,9 +1,6 @@
 version: "2.1"
 
 services:
-  rabbitmq:
-    image: rabbitmq:3.6.9
-    container_name: rabbit
   mysql:
     command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
     container_name: db
@@ -18,7 +15,6 @@ services:
     volumes:
       - ..:/edx/app/xqueue/xqueue
     depends_on:
-      - rabbitmq
       - mysql
     environment:
       DB_HOST: "db"

--- a/queue/management/commands/delete_old_submissions.py
+++ b/queue/management/commands/delete_old_submissions.py
@@ -1,0 +1,89 @@
+"""
+Remove old submissions after they were lost or returned to the LMS
+"""
+
+import logging
+import time
+from datetime import datetime, timedelta
+from queue.models import Submission
+
+import pytz
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Delete old submissions by chunks for large databases
+    """
+
+    # Default maximum number of expired tokens to delete in a single transaction.
+    DEFAULT_CHUNK_SIZE = 1000
+
+    # Default seconds to sleep between chunked deletes of expired tokens.
+    DEFAULT_SLEEP_BETWEEN_DELETES = 0
+
+    # Default seconds to sleep between chunked deletes of expired tokens.
+    DEFAULT_DAYS_OLD = 7
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--chunk_size',
+            default=self.DEFAULT_CHUNK_SIZE,
+            type=int,
+            help='Maximum number of expired tokens to delete in one transaction.'
+        )
+        parser.add_argument(
+            '--sleep_between',
+            default=self.DEFAULT_SLEEP_BETWEEN_DELETES,
+            type=float,
+            help='Seconds to sleep between chunked delete of expired tokens.'
+        )
+        parser.add_argument(
+            '--days_old',
+            default=self.DEFAULT_DAYS_OLD,
+            type=int,
+            help='How many days of submissions to keep'
+        )
+
+    def handle(self, *args, **options):
+        """
+        Deletes old submissions, chunking the deletes to avoid long table/row locks.
+        """
+        # Process the command arguments.
+        chunk_size = options.get('chunk_size', self.DEFAULT_CHUNK_SIZE)
+        if chunk_size <= 0:
+            raise CommandError('Only positive chunk size is allowed ({}).'.format(chunk_size))
+        sleep_between = options.get('sleep_between', self.DEFAULT_SLEEP_BETWEEN_DELETES)
+        if sleep_between < 0:
+            raise CommandError('Only non-negative sleep between seconds is allowed ({}).'.format(sleep_between))
+        days_old = options.get('days_old', self.DEFAULT_DAYS_OLD)
+        if days_old < 0:
+            raise CommandError('Only non-negative days old is allowed ({}).'.format(days_old))
+
+        delete_date = datetime.now(pytz.utc) - timedelta(days=days_old)
+
+        old_submissions = Submission.objects.filter(arrival_time__lte=delete_date)
+        total_old_submissions = old_submissions.count()
+
+        log.info("STARTED: Deleting %s submissions older than '%s' with chunk size of %s and %s seconds between chunk.",
+                 total_old_submissions, delete_date, chunk_size, sleep_between
+                 )
+
+        total_deletions = 0
+        while old_submissions.exists():
+            qs = old_submissions[:chunk_size]
+            batch_ids = qs.values_list('id', flat=True)
+            deletions_now = batch_ids.count()
+            log.info("Deleting %s expired submissions...", deletions_now)
+            with transaction.atomic():
+                Submission.objects.filter(pk__in=list(batch_ids)).delete()
+                total_deletions += deletions_now
+
+            if old_submissions.exists():
+                log.info("Sleeping %s seconds...", sleep_between)
+                time.sleep(sleep_between)
+
+        log.info("FINISHED: Deleted %s old submissions tokens total.", total_deletions)

--- a/queue/management/commands/tests/test_delete_old_submissions.py
+++ b/queue/management/commands/tests/test_delete_old_submissions.py
@@ -1,0 +1,56 @@
+from datetime import datetime, timedelta
+from queue.models import Submission
+
+import pytz
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TransactionTestCase
+
+
+class CountQueuedSubmissionsTest(TransactionTestCase):
+    def _bulk_create(self, count=1, days_old=10, **create_params):
+        for i in range(count):
+            submission = self._create_submission(**create_params)
+            actual_arrival_time = datetime.now(pytz.utc) - timedelta(days=days_old)
+            Submission.objects.filter(pk=submission.id).update(arrival_time=actual_arrival_time)
+
+    def _create_submission(self, **create_params):
+        submission_params = dict(
+            retired=0,
+            queue_name=u'test',
+        )
+        submission_params.update(create_params)
+        return Submission.objects.create(**submission_params)
+
+    def test_deletes(self):
+        "Default is 10 days old, default is deleting older than 7 days"
+        self._bulk_create(30)
+        self.assertEquals(Submission.objects.count(), 30)
+        call_command('delete_old_submissions')
+        self.assertEquals(Submission.objects.count(), 0)
+
+    def test_undeleted(self):
+        self._bulk_create(15, 5)
+        self._bulk_create(15)
+        self.assertEquals(Submission.objects.count(), 30)
+        call_command('delete_old_submissions')
+        self.assertEquals(Submission.objects.count(), 15)
+
+    def test_chunks(self):
+        self._bulk_create(20)
+        call_command('delete_old_submissions', chunk_size=5, sleep_between=1)
+        self.assertEquals(Submission.objects.count(), 0)
+
+    def test_days_old(self):
+        self._bulk_create(20)
+        self.assertEquals(Submission.objects.count(), 20)
+        call_command('delete_old_submissions', days_old=2)
+        self.assertEquals(Submission.objects.count(), 0)
+
+    def test_bad_arguments(self):
+        with self.assertRaisesRegexp(CommandError, 'Only non-negative days old is allowed.*'):
+            call_command('delete_old_submissions', days_old=-1)
+        with self.assertRaisesRegexp(CommandError, 'Only non-negative sleep between seconds is allowed.*'):
+            call_command('delete_old_submissions', sleep_between=-2)
+        with self.assertRaisesRegexp(CommandError, 'Only positive chunk size is allowed.*'):
+            call_command('delete_old_submissions', chunk_size=-3)

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -23,7 +23,7 @@ more-itertools==4.1.0     # via pytest
 mysql-python==1.2.5
 newrelic==3.0.0.89
 path.py==11.0.1
-pbr==4.0.0                # via mock
+pbr==4.0.1                # via mock
 pluggy==0.6.0             # via pytest, tox
 py==1.5.3                 # via pytest, tox
 pycodestyle==2.3.1
@@ -37,7 +37,7 @@ pyyaml==3.12              # via edx-django-release-util
 requests==2.18.4
 six==1.11.0               # via edx-django-release-util, mock, more-itertools, pytest, tox
 tox-battery==0.5
-tox==2.9.1
+tox==3.0.0
 urllib3==1.22             # via requests
 virtualenv==15.2.0        # via tox
 wsgiref==0.1.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -21,7 +21,7 @@ more-itertools==4.1.0     # via pytest
 mysql-python==1.2.5
 newrelic==3.0.0.89
 path.py==11.0.1
-pbr==4.0.0                # via mock
+pbr==4.0.1                # via mock
 pluggy==0.6.0             # via pytest
 py==1.5.3                 # via pytest
 pytest-cov==2.5.1

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -14,6 +14,6 @@ py==1.5.3                 # via tox
 requests==2.18.4          # via codecov
 six==1.11.0               # via tox
 tox-battery==0.5
-tox==2.9.1
+tox==3.0.0
 urllib3==1.22             # via requests
 virtualenv==15.2.0        # via tox

--- a/script/max_pep8_violations
+++ b/script/max_pep8_violations
@@ -1,5 +1,5 @@
 #!/bin/bash
-DEFAULT_MAX=80
+DEFAULT_MAX=71
 
 pycodestyle . | tee /tmp/pep8-xqueue.log
 ERR=`grep -c ^ /tmp/pep8-xqueue.log `


### PR DESCRIPTION
This be default deletes 1000 rows at a time, but you can make that chunk
smaller/larger and sleep between deletes to help performance.
By default, it leaves you a week of submissions.