### PR TITLE
A submissions-per-queue management command

### DIFF
--- a/queue/management/commands/count_queued_submissions.py
+++ b/queue/management/commands/count_queued_submissions.py
@@ -1,0 +1,75 @@
+"""
+Check on currently queued submissions
+"""
+
+from __future__ import unicode_literals
+
+from queue.models import Submission
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Count
+
+try:
+    import newrelic.agent
+except ImportError:  # pragma: no cover
+    newrelic = None  # pylint: disable=invalid-name
+
+
+class Command(BaseCommand):
+    """
+    Count submissions per-queue that have not been retired
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--newrelic',
+            action='store_true',
+            help='Submit New Relic custom metrics'
+        )
+
+    def handle(self, *args, **options):
+        """
+        Return a list of queues and their unretired submissions.
+        If --newrelic is passed, these will be sent as a custom metric
+        to New Relic Insights
+        """
+        queue_counts = (
+                        Submission.objects.
+                        values('queue_name').
+                        filter(retired=False).
+                        annotate(queue_count=Count('queue_name')).
+                        order_by('-queue_count')
+        )
+
+        self.pretty_print_queues(queue_counts)
+
+        use_newrelic = options.get('newrelic')
+        if use_newrelic:
+            self.send_nr_metrics(queue_counts)
+
+    def pretty_print_queues(self, queue_counts):
+        """
+        Send a tabulated log output of the queues and the counts to the console
+        No output if there are no queued submissions
+        """
+
+        for queue in queue_counts:
+            self.stdout.write("{:<30} {:<10}".format(queue['queue_name'],
+                                                     queue['queue_count']))
+
+    def send_nr_metrics(self, queue_counts):
+        """
+        Send custom metrics to New Relic Insights
+        """
+        if not newrelic:  # pragma: no cover
+            raise CommandError("--newrelic cannot be used unless the newrelic library is installed")
+
+        newrelic.agent.initialize()
+        nr_app = newrelic.agent.register_application(name=settings.NEWRELIC_APPNAME, timeout=10.0)
+
+        for queue in queue_counts:
+            newrelic.agent.record_custom_metric(
+                'Custom/XQueueLength/{}[submissions]'.format(queue['queue_name']),
+                queue['queue_count'],
+                application=nr_app)

--- a/queue/management/commands/tests/test_count_queued_submissions.py
+++ b/queue/management/commands/tests/test_count_queued_submissions.py
@@ -1,0 +1,55 @@
+from queue.models import Submission
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils.six import StringIO
+from mock import call, patch
+
+
+class CountQueuedSubmissionsTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.stdout = StringIO()
+        super(CountQueuedSubmissionsTest, cls).setUpClass()
+
+    def _create_submission(self, **create_params):
+        submission_params = dict(
+            retired=0,
+            queue_name=u'test'
+        )
+        submission_params.update(create_params)
+        return Submission.objects.create(**submission_params)
+
+    def test_no_submissions(self):
+        call_command('count_queued_submissions', stdout=self.stdout)
+        self.assertEquals('', self.stdout.getvalue())
+
+    def test_no_unretired_submissions(self):
+        self._create_submission(retired=1)
+        call_command('count_queued_submissions', stdout=self.stdout)
+        self.assertEquals('', self.stdout.getvalue())
+
+    def test_submissions(self):
+        self._create_submission(queue_name="test1")
+        self._create_submission(queue_name="test1")
+        self._create_submission(queue_name="test3")
+        call_command('count_queued_submissions', stdout=self.stdout)
+        self.assertRegexpMatches(self.stdout.getvalue(), 'test1\s*2\s*\ntest3\s*1')
+
+    @patch('newrelic.agent')
+    def test_push_to_new_relic(self, mock_newrelic_agent):
+        self._create_submission(queue_name="test1")
+        self._create_submission(queue_name="test2")
+        self._create_submission(queue_name="test2")
+        call_command('count_queued_submissions', '--newrelic', stdout=self.stdout)
+        self.assertRegexpMatches(self.stdout.getvalue(), 'test2\s*2\s*\ntest1\s*1')
+
+        expected_nr_calls = [
+            call('test1', 1),
+            call('test2', 2)
+        ]
+
+        self.assertEquals(len(expected_nr_calls),
+                          mock_newrelic_agent.record_custom_metric.call_count)
+
+        mock_newrelic_agent.record_custom_metric.has_calls(expected_nr_calls, any_order=True)

--- a/script/max_pep8_violations
+++ b/script/max_pep8_violations
@@ -4,7 +4,7 @@ DEFAULT_MAX=71
 pycodestyle . | tee /tmp/pep8-xqueue.log
 ERR=`grep -c ^ /tmp/pep8-xqueue.log `
 MAX=${1-$DEFAULT_MAX}
-if [ $ERR -g $MAX ]; then
+if [ $ERR -gt $MAX ]; then
     echo "too many pep8 violations: $ERR (max is $MAX)"
     exit 1
 else

--- a/xqueue/aws_settings.py
+++ b/xqueue/aws_settings.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from django.conf import global_settings
 
@@ -63,3 +64,10 @@ AWS_QUERYSTRING_EXPIRE = ENV_TOKENS.get('UPLOAD_URL_EXPIRE', UPLOAD_URL_EXPIRE)
 SESSION_ENGINE = ENV_TOKENS.get('SESSION_ENGINE') or global_settings.SESSION_ENGINE
 # Use a custom cache setting from env; useful if, for example, the session engine uses cache and requires Memcached
 CACHES = ENV_TOKENS.get('CACHES') or global_settings.CACHES
+
+# To use newrelic agent from a management command, we need the app name and the license key
+# In order to register the agent with the license key it needs to be in the environment (or an otherwise
+# unused config file) before the later import of the agent by the command.
+NEWRELIC_APPNAME = ENV_TOKENS.get('NEWRELIC_APPNAME', NEWRELIC_APPNAME)
+if not os.environ.get('NEW_RELIC_LICENSE_KEY', '') and AUTH_TOKENS.get('NEWRELIC_LICENSE_KEY', ''):
+    os.environ['NEW_RELIC_LICENSE_KEY'] = AUTH_TOKENS.get('NEWRELIC_LICENSE_KEY')

--- a/xqueue/settings.py
+++ b/xqueue/settings.py
@@ -180,3 +180,8 @@ SUBMISSION_PROCESSING_DELAY = 1
 # Number of seconds to wait between checks for new submissions that need to be
 # sent to an external grader
 CONSUMER_DELAY = 10
+
+# This is normally used in the supervisor configuration but if you have a
+# standalone script, you need to report to the correct app (and aren't
+# already running inside NR)
+NEWRELIC_APPNAME = 'xqueue'


### PR DESCRIPTION
Useful to have xqueue tell you in a tabular printout if you have a bunch
of pending submissions.  Also able to send data to New Relic Insights.