### PR TITLE
Objects should be uploaded private by default

### DIFF
--- a/xqueue/aws_settings.py
+++ b/xqueue/aws_settings.py
@@ -57,6 +57,9 @@ XQUEUE_USERS = AUTH_TOKENS.get('USERS', None)
 
 # Use S3 as the default storage backend
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+# These are learner permissions and we generate signed URLs for external graders
+# to download.  The uploads should not be public by default.
+AWS_DEFAULT_ACL = 'private'
 AWS_STORAGE_BUCKET_NAME = UPLOAD_BUCKET
 AWS_LOCATION = UPLOAD_PATH_PREFIX
 AWS_QUERYSTRING_EXPIRE = ENV_TOKENS.get('UPLOAD_URL_EXPIRE', UPLOAD_URL_EXPIRE)


### PR DESCRIPTION
Since we're generating signed URLs, we should really make them private.

OPS-2114