### PR TITLE
The logging hasn't been configured yet

### DIFF
--- a/xqueue/aws_settings.py
+++ b/xqueue/aws_settings.py
@@ -2,5 +2,4 @@ import logging
 
 from production import *
 
-logger = logging.getLogger(__name__)
-logger.error("aws_settings is deprecated, please use xqueue.production instead")
+logging.error("aws_settings is deprecated, please use xqueue.production instead")


### PR DESCRIPTION
We'll let Django run the configuration as it finishes loading settings
and just use the default config to log this error.

I've confirmed that our standard logging handlers are configured
properly after this logs the deprecation.