### PR TITLE
Added minimal docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:2.7
+
+ENV PYTHONUNBUFFERED 1
+
+EXPOSE 8000
+
+WORKDIR /app
+
+COPY ./requirements.txt .
+RUN pip install -r requirements.txt
+
+ENV DJANGO_SETTINGS_MODULE 'xqueue.docker_settings'
+
+COPY . .
+
+RUN mkdir -p /log && mkdir /db -p
+
+CMD bash -c "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,12 @@ later following the SUBMISSION_PROCESSING_DELAY when it is requeued.
 Local Testing
 -------------
 
-XQueue is now available as a docker image used as part of Docker Devstack.
+XQueue can be started via docker-compose with following 
+command
+
+	docker-compose up
+
+Also XQueue is now available as a docker image used as part of Docker Devstack.
 You can start and provision it by using xqueue specific commands configured in
 your `devstack` directory
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+
+services:
+  app:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    ports:
+      - 8000:8000
+    environment:
+      DEBUG: 'True'
+    volumes:
+      - db:/db
+
+volumes:
+  db:
+    driver: local

--- a/xqueue/docker_settings.py
+++ b/xqueue/docker_settings.py
@@ -1,0 +1,8 @@
+from xqueue.settings import *
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': '/db/xqueue.sqlite',
+    }
+}


### PR DESCRIPTION
I added minimal docker configuration for easier start the system for local testing and development. In this case developer should have Docker engine and docker-compose installed on your machine. Then he can run only `docker-compose up` command in the root directory of project and xqueue server will start on 8000 port. 

I think this way is much easier than running with devstack. 