### PR TITLE
Add retire_old_submissions command

### DIFF
--- a/queue/management/commands/retire_failed_submissions.py
+++ b/queue/management/commands/retire_failed_submissions.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
     help = """
            Retire submissions that have more than settings.MAX_NUMBER_OF_FAILURES failures.\
            Notify the LMS/student that the queue will no longer attempt to process the submission.\
-           Optional <queue_name>
+           Optional <queue_name> - no queue name provided means all queues will be processed.
            """
 
     def add_arguments(self, parser):

--- a/queue/management/commands/retire_old_submissions.py
+++ b/queue/management/commands/retire_old_submissions.py
@@ -1,0 +1,47 @@
+import logging
+from queue.consumer import post_failure_to_lms
+from queue.models import Submission
+
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import dateparse, timezone
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = """
+           Retire submissions for the requested <queue> that were submitted from the LMS before <date>
+           It will send a message to the LMS so that learners know to resubmit, but will still be marked
+           as retired regardless of success contacting the LMS.
+           """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'queue_name',
+            help="Which queue to retire submissions for")
+
+        parser.add_argument(
+            '--retire-before',
+            dest='retire_before',
+            help='Date + time (UTC) to limit submissions up for retirement (arrival_time < YYYY-MM-DD HH:MM::SS)'
+            )
+
+    def handle(self, *args, **options):
+        submissions = Submission.objects.filter(queue_name=options['queue_name'], retired=False)
+        if options['retire_before']:
+            retire_before = dateparse.parse_datetime(options['retire_before'])
+            if retire_before:
+                log.info("finding submissions submitted before {}".format(retire_before))
+                if not timezone.is_aware(retire_before):
+                    retire_before = timezone.make_aware(retire_before, timezone.utc)
+                submissions = submissions.filter(arrival_time__lte=retire_before)
+            else:
+                raise CommandError("unable to parse datetime {}".format(options['retire_before']))
+
+        for submission in submissions:
+            log.info("Retiring submission id={} from queue '{}' ".format(submission.id, submission.queue_name))
+            submission.retired = True
+            submission.lms_ack = post_failure_to_lms(submission.xqueue_header)
+            if not submission.lms_ack:
+                log.error('Could not contact LMS to retire submission id={} - retired anyway'.format(submission.id))
+            submission.save()

--- a/queue/management/commands/tests/__init__.py
+++ b/queue/management/commands/tests/__init__.py
@@ -1,0 +1,20 @@
+from datetime import datetime, timedelta
+from queue.models import Submission
+
+import pytz
+
+
+def bulk_create_submissions(count=1, days_old=10, **create_params):
+    for i in range(count):
+        submission = create_submission(**create_params)
+        actual_arrival_time = datetime.now(pytz.utc) - timedelta(days=days_old)
+        Submission.objects.filter(pk=submission.id).update(arrival_time=actual_arrival_time)
+
+def create_submission(**create_params):
+    submission_params = dict(
+        retired=0,
+        queue_name=u'test',
+    )
+    submission_params.update(create_params)
+    return Submission.objects.create(**submission_params)
+

--- a/queue/management/commands/tests/__init__.py
+++ b/queue/management/commands/tests/__init__.py
@@ -10,6 +10,7 @@ def bulk_create_submissions(count=1, days_old=10, **create_params):
         actual_arrival_time = datetime.now(pytz.utc) - timedelta(days=days_old)
         Submission.objects.filter(pk=submission.id).update(arrival_time=actual_arrival_time)
 
+
 def create_submission(**create_params):
     submission_params = dict(
         retired=0,
@@ -17,4 +18,3 @@ def create_submission(**create_params):
     )
     submission_params.update(create_params)
     return Submission.objects.create(**submission_params)
-

--- a/queue/management/commands/tests/test_delete_old_submissions.py
+++ b/queue/management/commands/tests/test_delete_old_submissions.py
@@ -1,48 +1,33 @@
-from datetime import datetime, timedelta
+from queue.management.commands.tests import bulk_create_submissions
 from queue.models import Submission
 
-import pytz
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TransactionTestCase
 
 
-class CountQueuedSubmissionsTest(TransactionTestCase):
-    def _bulk_create(self, count=1, days_old=10, **create_params):
-        for i in range(count):
-            submission = self._create_submission(**create_params)
-            actual_arrival_time = datetime.now(pytz.utc) - timedelta(days=days_old)
-            Submission.objects.filter(pk=submission.id).update(arrival_time=actual_arrival_time)
-
-    def _create_submission(self, **create_params):
-        submission_params = dict(
-            retired=0,
-            queue_name=u'test',
-        )
-        submission_params.update(create_params)
-        return Submission.objects.create(**submission_params)
-
+class DeleteOldSubmissionsTest(TransactionTestCase):
     def test_deletes(self):
         "Default is 10 days old, default is deleting older than 7 days"
-        self._bulk_create(30)
+        bulk_create_submissions(30)
         self.assertEquals(Submission.objects.count(), 30)
         call_command('delete_old_submissions')
         self.assertEquals(Submission.objects.count(), 0)
 
     def test_undeleted(self):
-        self._bulk_create(15, 5)
-        self._bulk_create(15)
+        bulk_create_submissions(15, 5)
+        bulk_create_submissions(15)
         self.assertEquals(Submission.objects.count(), 30)
         call_command('delete_old_submissions')
         self.assertEquals(Submission.objects.count(), 15)
 
     def test_chunks(self):
-        self._bulk_create(20)
+        bulk_create_submissions(20)
         call_command('delete_old_submissions', chunk_size=5, sleep_between=1)
         self.assertEquals(Submission.objects.count(), 0)
 
     def test_days_old(self):
-        self._bulk_create(20)
+        bulk_create_submissions(20)
         self.assertEquals(Submission.objects.count(), 20)
         call_command('delete_old_submissions', days_old=2)
         self.assertEquals(Submission.objects.count(), 0)

--- a/queue/management/commands/tests/test_retire_failed_submissions.py
+++ b/queue/management/commands/tests/test_retire_failed_submissions.py
@@ -8,12 +8,12 @@ from django.core.management import call_command
 from django.test import TestCase
 
 
-class TestRetireSubmissions(TestCase):
+class TestRetireFailedSubmissions(TestCase):
     """
     Tests of the retire_submissions management command.
     """
     def test_all_queues(self):
-        path = 'queue.management.commands.retire_submissions.Command.retire_submissions'
+        path = 'queue.management.commands.retire_failed_submissions.Command.retire_submissions'
         with mock.patch(path) as mock_method:
-            call_command(u'retire_submissions', force=True)
+            call_command(u'retire_failed_submissions', force=True)
             assert mock_method.call_count == 1

--- a/queue/management/commands/tests/test_retire_old_submissions.py
+++ b/queue/management/commands/tests/test_retire_old_submissions.py
@@ -1,0 +1,60 @@
+"""
+Tests of the update_users management command.
+"""
+from __future__ import absolute_import
+
+from datetime import timedelta
+from queue.management.commands.tests import bulk_create_submissions
+from queue.models import Submission
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+from django.utils import timezone
+from mock import patch
+
+
+class RetireOldSubmissionsTest(TestCase):
+
+    def count_unretired(self, count):
+        self.assertEquals(Submission.objects.filter(retired=False).count(),
+                          count)
+
+    @patch('queue.management.commands.retire_old_submissions.post_failure_to_lms', return_value=True)
+    def test_deletes(self, mock_post_to_lms):
+        "Retire all the submissions"
+        bulk_create_submissions(5)
+        self.count_unretired(5)
+        call_command('retire_old_submissions', 'test')
+        self.count_unretired(0)
+
+    @patch('queue.management.commands.retire_old_submissions.post_failure_to_lms', return_value=True)
+    def test_undeleted(self, mock_post_to_lms):
+        """
+        Create some older submissions and only retire those old ones
+        Defaults are 10 days old, add 4 day old ones and retire anything 5 days or older
+        """
+        bulk_create_submissions(5, 4)
+        bulk_create_submissions(5)
+        self.count_unretired(10)
+        older = timezone.now() - timedelta(5)
+        call_command('retire_old_submissions', 'test', retire_before=older.isoformat())
+        self.count_unretired(5)
+
+    @patch('queue.management.commands.retire_old_submissions.log')
+    @patch('queue.management.commands.retire_old_submissions.post_failure_to_lms', return_value=False)
+    def test_deletes_failing_to_connect_to_lms(self, mock_post_to_lms, mock_logger):
+        "Retire all the submissions, and fail the LMS callback"
+
+        bulk_create_submissions(5)
+        self.count_unretired(5)
+        call_command('retire_old_submissions', 'test')
+        mock_logger.error.assert_called()
+        logs, _ = mock_logger.error.call_args
+        self.assertRegexpMatches(logs[0], r'Could not contact LMS to retire submission')
+        self.count_unretired(0)
+
+    def test_bad_arguments(self):
+        with self.assertRaisesRegexp(CommandError, 'unable to parse datetime'):
+            call_command('retire_old_submissions', 'test', retire_before='2018-04-03')


### PR DESCRIPTION
The old command was "retire failed submissions" so I renamed it

New command requires a queue and allows you to also only retire old submissions.

OPS-3057
