### PR TITLE
BOM-1175

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,31 +3,19 @@ services:
   - docker
 sudo: required
 
+python:
+- 3.5
+
+env:
+- TOXENV=django111
+- TOXENV=django20
+- TOXENV=django21
+- TOXENV=django22
+
 matrix:
   include:
-    - python: "2.7"
-      env: TOXENV=py27-django111
-    - python: "2.7"
-      env: TOXENV=py27-quality
-    - python: "3.5"
-      env: TOXENV=py35-django111
-    - python: "3.5"
-      env: TOXENV=py35-quality
-    - python: "3.6"
-      env: TOXENV=py36-django111
-    - python: "3.6"
-      env: TOXENV=py36-django20
-    - python: "3.6"
-      env: TOXENV=py36-django21
-    - python: "3.7"
-      env: TOXENV=py36-django111
-    - python: "3.7"
-      env: TOXENV=py36-django20
-    - python: "3.7"
-      env: TOXENV=py36-django21
-  allow_failures:
-    - python: "3.6"
-    - python: "3.7"
+  - python: 3.5
+    env: TOXENV=py35-quality
 
 before_install:
   - docker-compose -f .travis/docker-compose-travis.yml up -d

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35}-django111,py{36,37}-django{111,20,21},py{27,35}-quality
+envlist = py{35}-django{111,20,21,22}-quality
 skipsdist=True
 
 [pycodestyle]
@@ -16,6 +16,7 @@ deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
+    django22: Django>=2.1,<2.3
     -r{toxinidir}/requirements/test.txt
 passenv =
     TRAVIS*

--- a/xqueue/settings.py
+++ b/xqueue/settings.py
@@ -91,7 +91,7 @@ MEDIA_URL = ''
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'uofqkujp@z#_vtwct+v716z+^3hijelj1^fkydwo2^pbkxghfq'
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
Updating travis and tox.
BOM-1174 and 1175.
removed py2 support from tox and travis.