### PR TITLE
Fix unittests not running in travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,7 @@ python:
 
 env:
 - TOXENV=django22
-
-matrix:
-  include:
-  - python: 3.5
-    env: TOXENV=py35-quality
+- TOXENV=py35-quality
 
 before_install:
   - docker-compose -f .travis/docker-compose-travis.yml up -d

--- a/tox.ini
+++ b/tox.ini
@@ -37,9 +37,3 @@ deps =
     {[testenv:quality]deps}
 commands =
     {[testenv:quality]commands}
-
-[testenv:py27-quality]
-deps =
-    {[testenv:quality]deps}
-commands =
-    {[testenv:quality]commands}


### PR DESCRIPTION
After this change https://github.com/edx/xqueue/pull/703, unittests stopped running in travis builds.