### PR TITLE
[BD-6] Update tests to run using python 3.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,25 @@ sudo: required
 
 python:
 - 3.5
-- 3.8
 
 env:
-- TOXENV=django22
+- TOXENV=py35-django22
+- TOXENV=py38-django22
 - TOXENV=quality
 
 before_install:
   - docker-compose -f .travis/docker-compose-travis.yml up -d
-  - docker exec xqueue bash -c "source /edx/app/xqueue/venvs/xqueue/bin/activate; cd /edx/app/xqueue/xqueue/; pip install -r requirements/travis.txt"
+  - docker exec xqueue bash -c "cd /edx/app/xqueue/xqueue/; pip install -r requirements/travis.txt"
+install:
+  - docker exec -t xqueue bash -c "
+    sudo add-apt-repository ppa:deadsnakes/ppa -y;
+    sudo apt-get update -y;
+    sudo apt-get install python3.8 python3.8-distutils python3.8-dev -y;"
 script:
-  - docker exec xqueue bash -c "source /edx/app/xqueue/venvs/xqueue/bin/activate; cd /edx/app/xqueue/xqueue/; TOXENV=${TOXENV} tox"
+  - docker exec xqueue bash -c "cd /edx/app/xqueue/xqueue/; TOXENV=${TOXENV} tox"
 after_success:
   - pip install -r requirements/travis.txt
-  - docker exec xqueue bash -c "source /edx/app/xqueue/venvs/xqueue/bin/activate; cd /edx/app/xqueue/xqueue/; coverage combine; coverage xml"
+  - docker exec xqueue bash -c "cd /edx/app/xqueue/xqueue/; coverage combine; coverage xml"
   - codecov
 branches:
   only:


### PR DESCRIPTION
Run tests using python 3.5 and python 3.8 in the Docker container.
Re-opening this PR https://github.com/edx/xqueue/pull/743 since edx bot does not allowed me to re-open it.

**Reviewers**
- [ ] @awais786 
- [ ] @morenol