### PR TITLE
Add support for private.py in devstack

### DIFF
--- a/xqueue/devstack.py
+++ b/xqueue/devstack.py
@@ -47,3 +47,8 @@ LOGGING['handlers']['local'] = {
 # It's probably ok to search your DB for push queues every minute (or even longer) on a
 # development instance, rather than the brief prod timespan.
 CONSUMER_DELAY = 60
+
+#####################################################################
+# See if the developer has any local overrides.
+if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
+    from .private import *  # pylint: disable=import-error,wildcard-import


### PR DESCRIPTION
### Description
Adding support for a `private.py` file in devstack just like the other services have.