### PR TITLE
Fix NameError in devstack settings

### DIFF
--- a/xqueue/devstack.py
+++ b/xqueue/devstack.py
@@ -49,5 +49,5 @@ CONSUMER_DELAY = 60
 
 #####################################################################
 # See if the developer has any local overrides.
-if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
+if os.path.isfile(os.path.join(dirname(abspath(__file__)), 'private.py')):
     from .private import *  # pylint: disable=import-error,wildcard-import


### PR DESCRIPTION
The devstack build is failing because of a NameError in the xqueue devstack settings. See for instance: https://travis-ci.org/github/edx/devstack/jobs/725135381

```
docker-compose exec xqueue bash -c 'source /edx/app/xqueue/xqueue_env && cd /edx/app/xqueue/xqueue && python manage.py migrate'
/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release ofcryptography. Please upgrade your Python.
  from cryptography.hazmat.backends import default_backend
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/edx/app/xqueue/venvs/xqueue/lib/python3.5/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/edx/app/xqueue/venvs/xqueue/lib/python3.5/site-packages/django/core/management/__init__.py", line 325, in execute
    settings.INSTALLED_APPS
  File "/edx/app/xqueue/venvs/xqueue/lib/python3.5/site-packages/django/conf/__init__.py", line 79, in __getattr__
    self._setup(name)
  File "/edx/app/xqueue/venvs/xqueue/lib/python3.5/site-packages/django/conf/__init__.py", line 66, in _setup
    self._wrapped = Settings(settings_module)
  File "/edx/app/xqueue/venvs/xqueue/lib/python3.5/site-packages/django/conf/__init__.py", line 157, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/edx/app/xqueue/venvs/xqueue/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 665, in exec_module\
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/edx/app/xqueue/xqueue/xqueue/devstack.py", line 52, in <module>
    if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
NameError: name 'join' is not defined
Makefile:224: recipe for target 'dev.provision.xqueue' failed
make: *** [dev.provision.xqueue] Error 1
```