### PR TITLE
Fix calls to os.path functions in devstack settings

### DIFF
--- a/xqueue/devstack.py
+++ b/xqueue/devstack.py
@@ -49,5 +49,5 @@ CONSUMER_DELAY = 60
 
 #####################################################################
 # See if the developer has any local overrides.
-if os.path.isfile(os.path.join(dirname(abspath(__file__)), 'private.py')):
+if os.path.isfile(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'private.py')):
     from .private import *  # pylint: disable=import-error,wildcard-import


### PR DESCRIPTION
This should fix the devstack build of xqueue.

E.g: https://travis-ci.org/github/edx/devstack/jobs/728269558