### PR TITLE
Update Travis MySQL Image to 5.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ branches:
 before_install:
   - docker-compose -f .travis/docker-compose-travis.yml up -d
   - docker exec xqueue bash -c "cd /edx/app/xqueue/xqueue/; pip3 install -r requirements/travis.txt"
-
 install:
   - docker exec -t xqueue bash -c "
     sudo add-apt-repository ppa:deadsnakes/ppa -y;

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
         TOXENV="py35-django22"
       after_success:
         - pip3 install -r requirements/travis.txt
-        - docker exec xqueue bash -c "cd /edx/app/xqueue/xqueue/; coverage combine; coverage xml"
+        - docker exec xqueue bash -c "cd /edx/app/xqueue/xqueue/; coverage xml"
         - codecov
     - python: 3.8
       env:
@@ -35,7 +35,7 @@ matrix:
         TOXENV="py38-django22"
       after_success:
         - python3.8 -m pip install -r requirements/travis.txt
-        - docker exec xqueue bash -c "cd /edx/app/xqueue/xqueue/; coverage combine; coverage xml"
+        - docker exec xqueue bash -c "cd /edx/app/xqueue/xqueue/; coverage xml"
         - codecov
     - python: 3.5
       env:

--- a/.travis/docker-compose-travis.yml
+++ b/.travis/docker-compose-travis.yml
@@ -7,7 +7,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ""
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-    image: mysql:5.6
+    image: mysql:5.7
   xqueue:
     container_name: xqueue
     image: edxops/xqueue:latest

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,6 @@ requirements: ## install development environment requirements
 
 test: requirements clean
 	pytest --cov --cov-report= --ds=xqueue.test_settings submission_queue
-	coverage combine
 	coverage report -m
 
 test-all: ## run tests on every supported Python/Django combination

--- a/test_framework/integration_framework.py
+++ b/test_framework/integration_framework.py
@@ -203,6 +203,8 @@ class PassiveGraderStub(ForkingMixIn, HTTPServer, GraderStubBase):
         else:
             cls.worker_list = []
 
+        from django.db import connection
+        connection.close()
         for i in range(num_workers):
             worker = Worker(queue_name=queue_name, worker_url=destination_url)
             worker.start()
@@ -225,7 +227,10 @@ class PassiveGraderStub(ForkingMixIn, HTTPServer, GraderStubBase):
         server_thread.start()
 
     def stop(self):
-        """Stop listening on the local port and close the socket"""
+        """Stop worker processes, stop listening on the local port, and close the socket"""
+        for worker in self.worker_list:
+            worker.terminate()
+
         self.shutdown()
 
         # We also need to manually close the socket, so it can

--- a/xqueue/test_settings.py
+++ b/xqueue/test_settings.py
@@ -19,7 +19,7 @@ DATABASES = {
         'ENGINE': 'django.db.backends.mysql',
         # pytest/django TestCase instances auto-prefix test_ onto the NAME
         'NAME': 'xqueue',
-        'HOST': os.environ.get('DB_HOST', 'edx.devstack.mysql'),
+        'HOST': os.environ.get('DB_HOST', 'edx.devstack.mysql57'),
         # Wrap all view methods in an atomic transaction automatically.
         'ATOMIC_REQUESTS': True
     }


### PR DESCRIPTION
Updated the devstack and Travis database settings to use MySQL 5.7 instead of 5.6.  This triggered problems in one test due to how `multiprocessing` interacts with Django database connections, as described in https://stackoverflow.com/questions/24406092/when-using-multiprocessing-to-access-mysql-it-always-throws-the-following-error .  The test was updated to close the parent process's connection before forking the sub-processes.

Also, nothing ever shut down the worker processes explicitly once they were started, so added that to the test grader stub.

Finally, coverage combine started failing with a "No data to combine" message, even though it doesn't seem like anything relevant has changed in this PR and it was previously working on master. The command is redundant anyway since pytest-cov does the combining into a single .coverage file before pytest exits, so it was removed.