### PR TITLE
Upgrade Django to 2.2.17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ botocore==1.18.16         # via boto3, s3transfer
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 django-storages==1.10.1   # via -r requirements/base.in
-django==2.2.16            # via -r requirements/base.in, django-storages, edx-django-release-util
+django==2.2.17            # via -r requirements/base.in, django-storages, edx-django-release-util
 edx-django-release-util==0.4.4  # via -r requirements/base.in
 gunicorn==0.16.1          # via -r requirements/base.in
 idna==2.10                # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,7 +16,7 @@ codecov==2.1.10           # via -r requirements/travis.txt
 coverage==5.3             # via -r requirements/test.txt, -r requirements/travis.txt, codecov, pytest-cov
 distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
 django-storages==1.10.1   # via -r requirements/test.txt
-django==2.2.16            # via -r requirements/test.txt, django-storages, edx-django-release-util
+django==2.2.17            # via -r requirements/test.txt, django-storages, edx-django-release-util
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 gunicorn==0.16.1          # via -r requirements/test.txt


### PR DESCRIPTION
This is to make sure that we use the same Django version for all applications.

This PR should be merged in time for the Koa release (cc @nedbat); it is ready for review.