### PR TITLE
feat: Upgrade to Django 3.2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    make upgrade
 #
+asgiref==3.4.1
+    # via django
 backoff==1.11.1
     # via -r requirements/base.in
 boto3==1.18.55
@@ -16,9 +18,8 @@ certifi==2021.5.30
     # via requests
 charset-normalizer==2.0.6
     # via requests
-django==2.2.24
+django==3.2.8
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
     #   django-crum
     #   django-storages

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,7 +4,7 @@
 mysqlclient
 backoff
 boto3
-Django
+Django<4
 django-storages
 edx-django-release-util
 edx-django-utils

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,7 +4,7 @@
 mysqlclient
 backoff
 boto3
-Django >= 1.11, <2.3
+Django
 django-storages
 edx-django-release-util
 edx-django-utils

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -9,4 +9,4 @@
 # linking to it here is good.
 
 # Common constraints for edx repos
--c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+-c common_constraints.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+asgiref==3.4.1
+    # via
+    #   -r requirements/test.txt
+    #   django
 attrs==21.2.0
     # via
     #   -r requirements/test.txt
@@ -47,9 +51,8 @@ distlib==0.3.3
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==2.2.24
+django==3.2.8
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   django-crum
     #   django-storages

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+asgiref==3.4.1
+    # via
+    #   -r requirements/../requirements.txt
+    #   django
 attrs==21.2.0
     # via pytest
 backoff==1.11.1
@@ -26,7 +30,6 @@ charset-normalizer==2.0.6
 coverage[toml]==6.0
     # via pytest-cov
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/../requirements.txt
     #   django-crum
     #   django-storages


### PR DESCRIPTION
This reverts commit 5bf6e4f4cd2f51d0561e6ce7beae120efab3b209.

We merged a workaround for the 3.2 performance issues seen before, so we are going to upgrade once again.