### PR TITLE
fix: Use value field instead of boolean for retired queries.

### DIFF
--- a/submission_queue/lms_interface.py
+++ b/submission_queue/lms_interface.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
-from django.db import transaction
+from django.db import transaction, models
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 
@@ -90,7 +90,9 @@ def _invalidate_prior_submissions(lms_callback_url):
         (user, module-id). This function relies on the fact that lms_callback_url
         takes the form: /path/to/callback/<user>/<id>/...
     '''
-    prior_submissions = Submission.objects.filter(lms_callback_url=lms_callback_url[:128], retired=False)
+    prior_submissions = Submission.objects.filter(
+        lms_callback_url=lms_callback_url[:128], retired=models.Value(0)
+    )
     prior_submissions.update(retired=True)
 
 

--- a/submission_queue/management/commands/count_queued_submissions.py
+++ b/submission_queue/management/commands/count_queued_submissions.py
@@ -8,7 +8,7 @@ import boto3
 import botocore
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.db.models import Count
+from django.db.models import Count, Value
 from six.moves import zip_longest
 
 try:
@@ -43,7 +43,7 @@ class Command(BaseCommand):
         queue_counts = (
             Submission.objects.
                 values('queue_name').
-                filter(retired=False).
+                filter(retired=Value(0)).
                 annotate(queue_count=Count('queue_name')).
                 order_by('-queue_count')
         )

--- a/submission_queue/management/commands/retire_failed_submissions.py
+++ b/submission_queue/management/commands/retire_failed_submissions.py
@@ -2,6 +2,7 @@ import logging
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.db import models
 
 from submission_queue.consumer import post_failure_to_lms
 from submission_queue.models import Submission
@@ -35,12 +36,12 @@ class Command(BaseCommand):
 
         queue_names = options['queue_name']
         if len(queue_names) == 0:
-            failed_submissions = Submission.objects.filter(retired=False)
+            failed_submissions = Submission.objects.filter(retired=models.Value(0))
             failed_submissions = failed_submissions.exclude(num_failures=0)
             self.retire_submissions(failed_submissions, force)
         else:
             for queue_name in queue_names:
-                failed_submissions = Submission.objects.filter(queue_name=queue_name, retired=False)
+                failed_submissions = Submission.objects.filter(queue_name=queue_name, retired=models.Value(0))
                 failed_submissions = failed_submissions.exclude(num_failures=0)
                 self.retire_submissions(failed_submissions, force)
 

--- a/submission_queue/management/commands/retire_old_submissions.py
+++ b/submission_queue/management/commands/retire_old_submissions.py
@@ -3,6 +3,7 @@ from submission_queue.consumer import post_failure_to_lms
 from submission_queue.models import Submission
 
 from django.core.management.base import BaseCommand, CommandError
+from django.db import models
 from django.utils import dateparse, timezone
 
 log = logging.getLogger(__name__)
@@ -27,7 +28,7 @@ class Command(BaseCommand):
             )
 
     def handle(self, *args, **options):
-        submissions = Submission.objects.filter(queue_name=options['queue_name'], retired=False)
+        submissions = Submission.objects.filter(queue_name=options['queue_name'], retired=models.Value(0))
         if options['retire_before']:
             retire_before = dateparse.parse_datetime(options['retire_before'])
             if retire_before:

--- a/submission_queue/models.py
+++ b/submission_queue/models.py
@@ -25,7 +25,7 @@ class SubmissionManager(models.Manager):
         """
         How many unretired submissions are available for a queue
         """
-        return self.time_filter('pull_time').filter(queue_name=queue_name, retired=False).count()
+        return self.time_filter('pull_time').filter(queue_name=queue_name, retired=models.Value(0)).count()
 
     def get_single_unretired_submission(self, queue_name):
         '''


### PR DESCRIPTION
We made this fix in a few places in a previous commit but there were many that we did not
update. This is an update to ensure performance is still good in Django 3.2.