### PR TITLE
chore: manually run make upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,15 +8,15 @@ asgiref==3.4.1
     # via django
 backoff==1.11.1
     # via -r requirements/base.in
-boto3==1.18.55
+boto3==1.18.63
     # via -r requirements/base.in
-botocore==1.21.55
+botocore==1.21.63
     # via
     #   boto3
     #   s3transfer
-certifi==2021.5.30
+certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via requests
 django==3.2.8
     # via
@@ -27,7 +27,7 @@ django==3.2.8
     #   edx-django-utils
 django-crum==0.7.9
     # via edx-django-utils
-django-storages==1.11.1
+django-storages==1.12.2
     # via -r requirements/base.in
 django-waffle==2.2.1
     # via edx-django-utils
@@ -37,7 +37,7 @@ edx-django-utils==4.4.0
     # via -r requirements/base.in
 gunicorn==20.1.0
     # via -r requirements/base.in
-idna==3.2
+idna==3.3
     # via requests
 isort==5.9.3
     # via -r requirements/base.in
@@ -47,7 +47,7 @@ jmespath==0.10.0
     #   botocore
 mysqlclient==2.0.3
     # via -r requirements/base.in
-newrelic==7.0.0.166
+newrelic==7.2.2.169
     # via
     #   -r requirements/base.in
     #   edx-django-utils
@@ -67,7 +67,7 @@ pytz==2021.3
     # via
     #   -r requirements/base.in
     #   django
-pyyaml==5.4.1
+pyyaml==6.0
     # via edx-django-release-util
 requests==2.26.0
     # via -r requirements/base.in
@@ -80,7 +80,7 @@ six==1.16.0
     #   python-memcached
 sqlparse==0.4.2
     # via django
-stevedore==3.4.0
+stevedore==3.5.0
     # via edx-django-utils
 urllib3==1.26.7
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,21 +6,21 @@
 #
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-certifi==2021.5.30
+certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==6.0
+coverage==6.0.2
     # via codecov
 distlib==0.3.3
     # via virtualenv
-filelock==3.3.0
+filelock==3.3.1
     # via
     #   tox
     #   virtualenv
-idna==3.2
+idna==3.3
     # via requests
 packaging==21.0
     # via tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -3,6 +3,11 @@
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
 
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,30 +18,30 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-boto3==1.18.55
+boto3==1.18.63
     # via -r requirements/test.txt
-botocore==1.21.55
+botocore==1.21.63
     # via
     #   -r requirements/test.txt
     #   boto3
     #   s3transfer
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   requests
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   requests
-click==8.0.1
+click==8.0.3
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
 codecov==2.1.12
     # via -r requirements/ci.txt
-coverage[toml]==6.0
+coverage[toml]==6.0.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -62,7 +62,7 @@ django-crum==0.7.9
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-django-storages==1.11.1
+django-storages==1.12.2
     # via -r requirements/test.txt
 django-waffle==2.2.1
     # via
@@ -72,14 +72,14 @@ edx-django-release-util==1.1.0
     # via -r requirements/test.txt
 edx-django-utils==4.4.0
     # via -r requirements/test.txt
-filelock==3.3.0
+filelock==3.3.1
     # via
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
 gunicorn==20.1.0
     # via -r requirements/test.txt
-idna==3.2
+idna==3.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -97,7 +97,7 @@ jmespath==0.10.0
     #   botocore
 mysqlclient==2.0.3
     # via -r requirements/test.txt
-newrelic==7.0.0.166
+newrelic==7.2.2.169
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -113,11 +113,11 @@ pbr==5.6.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-pep517==0.11.0
+pep517==0.12.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pip-tools==6.3.0
+pip-tools==6.4.0
     # via -r requirements/pip-tools.txt
 platformdirs==2.4.0
     # via
@@ -139,7 +139,7 @@ py==1.10.0
     #   -r requirements/test.txt
     #   pytest
     #   tox
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via -r requirements/quality.txt
 pyparsing==2.4.7
     # via
@@ -167,7 +167,9 @@ pytz==2021.3
     # via
     #   -r requirements/test.txt
     #   django
-pyyaml==5.4.1
+pywatchman==1.4.1 ; "linux" in sys_platform
+    # via -r requirements/dev.in
+pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   edx-django-release-util
@@ -193,7 +195,7 @@ sqlparse==0.4.2
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-click==8.0.1
+click==8.0.3
     # via pip-tools
-pep517==0.11.0
+pep517==0.12.0
     # via pip-tools
-pip-tools==6.3.0
+pip-tools==6.4.0
     # via -r requirements/pip-tools.in
 tomli==1.2.1
     # via pep517

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,5 +4,5 @@
 #
 #    make upgrade
 #
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via -r requirements/quality.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,22 +12,22 @@ attrs==21.2.0
     # via pytest
 backoff==1.11.1
     # via -r requirements/../requirements.txt
-boto3==1.18.55
+boto3==1.18.63
     # via -r requirements/../requirements.txt
-botocore==1.21.55
+botocore==1.21.63
     # via
     #   -r requirements/../requirements.txt
     #   boto3
     #   s3transfer
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   -r requirements/../requirements.txt
     #   requests
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via
     #   -r requirements/../requirements.txt
     #   requests
-coverage[toml]==6.0
+coverage[toml]==6.0.2
     # via pytest-cov
     # via
     #   -r requirements/../requirements.txt
@@ -39,7 +39,7 @@ django-crum==0.7.9
     # via
     #   -r requirements/../requirements.txt
     #   edx-django-utils
-django-storages==1.11.1
+django-storages==1.12.2
     # via -r requirements/../requirements.txt
 django-waffle==2.2.1
     # via
@@ -51,7 +51,7 @@ edx-django-utils==4.4.0
     # via -r requirements/../requirements.txt
 gunicorn==20.1.0
     # via -r requirements/../requirements.txt
-idna==3.2
+idna==3.3
     # via
     #   -r requirements/../requirements.txt
     #   requests
@@ -66,7 +66,7 @@ jmespath==0.10.0
     #   botocore
 mysqlclient==2.0.3
     # via -r requirements/../requirements.txt
-newrelic==7.0.0.166
+newrelic==7.2.2.169
     # via
     #   -r requirements/../requirements.txt
     #   edx-django-utils
@@ -109,7 +109,7 @@ pytz==2021.3
     # via
     #   -r requirements/../requirements.txt
     #   django
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -r requirements/../requirements.txt
     #   edx-django-release-util
@@ -129,7 +129,7 @@ sqlparse==0.4.2
     # via
     #   -r requirements/../requirements.txt
     #   django
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   -r requirements/../requirements.txt
     #   edx-django-utils


### PR DESCRIPTION
Manually run `make upgrade` to fix failing devstack provisioning