### PR TITLE
chore: Upgrade Python requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,21 +4,25 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.1
     # via django
-backoff==1.11.1
+backoff==2.0.1
     # via -r requirements/base.in
-boto3==1.20.46
+boto3==1.23.0
     # via -r requirements/base.in
-botocore==1.23.46
+botocore==1.26.0
     # via
     #   boto3
     #   s3transfer
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.11
+cffi==1.15.0
+    # via pynacl
+charset-normalizer==2.0.12
     # via requests
-django==3.2.12
+click==8.1.3
+    # via edx-django-utils
+django==3.2.13
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
@@ -30,11 +34,11 @@ django-crum==0.7.9
     # via edx-django-utils
 django-storages==1.12.3
     # via -r requirements/base.in
-django-waffle==2.3.0
+django-waffle==2.4.1
     # via edx-django-utils
-edx-django-release-util==1.1.1
+edx-django-release-util==1.2.0
     # via -r requirements/base.in
-edx-django-utils==4.5.0
+edx-django-utils==4.8.1
     # via -r requirements/base.in
 gunicorn==20.1.0
     # via -r requirements/base.in
@@ -42,21 +46,25 @@ idna==3.3
     # via requests
 isort==5.10.1
     # via -r requirements/base.in
-jmespath==0.10.0
+jmespath==1.0.0
     # via
     #   boto3
     #   botocore
 mysqlclient==2.1.0
     # via -r requirements/base.in
-newrelic==7.4.0.172
+newrelic==7.10.0.175
     # via
     #   -r requirements/base.in
     #   edx-django-utils
-path.py==11.0.1
+path-py==11.0.1
     # via -r requirements/base.in
-pbr==5.8.0
+pbr==5.9.0
     # via stevedore
 psutil==5.9.0
+    # via edx-django-utils
+pycparser==2.21
+    # via cffi
+pynacl==1.5.0
     # via edx-django-utils
 python-dateutil==2.8.2
     # via botocore
@@ -64,7 +72,7 @@ python-memcached==1.59
     # via -r requirements/base.in
 python-termstyle==0.1.10
     # via -r requirements/base.in
-pytz==2021.3
+pytz==2022.1
     # via
     #   -r requirements/base.in
     #   django
@@ -72,7 +80,7 @@ pyyaml==6.0
     # via edx-django-release-util
 requests==2.27.1
     # via -r requirements/base.in
-s3transfer==0.5.0
+s3transfer==0.5.2
     # via boto3
 six==1.16.0
     # via
@@ -83,7 +91,7 @@ sqlparse==0.4.2
     # via django
 stevedore==3.5.0
     # via edx-django-utils
-urllib3==1.26.8
+urllib3==1.26.9
     # via
     #   botocore
     #   requests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,15 +6,15 @@
 #
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.11
+charset-normalizer==2.0.12
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==6.3.1
+coverage==6.3.3
     # via codecov
 distlib==0.3.4
     # via virtualenv
-filelock==3.4.2
+filelock==3.7.0
     # via
     #   tox
     #   virtualenv
@@ -22,13 +22,13 @@ idna==3.3
     # via requests
 packaging==21.3
     # via tox
-platformdirs==2.4.1
+platformdirs==2.5.2
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via packaging
 requests==2.27.1
     # via codecov
@@ -38,13 +38,13 @@ six==1.16.0
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.24.5
+tox==3.25.0
     # via
     #   -r requirements/ci.in
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.8
+urllib3==1.26.9
     # via requests
-virtualenv==20.13.0
+virtualenv==20.14.1
     # via tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -26,5 +26,5 @@ elasticsearch<7.14.0
 
 setuptools<60
 
-# redis 4 client doesn't play nicely with redis 3 server
-redis<4
+# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
+django-simple-history==3.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.1
     # via
     #   -r requirements/test.txt
     #   django
@@ -12,11 +12,11 @@ attrs==21.4.0
     # via
     #   -r requirements/test.txt
     #   pytest
-backoff==1.11.1
+backoff==2.0.1
     # via -r requirements/test.txt
-boto3==1.20.46
+boto3==1.23.0
     # via -r requirements/test.txt
-botocore==1.23.46
+botocore==1.26.0
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -26,18 +26,24 @@ certifi==2021.10.8
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   requests
-charset-normalizer==2.0.11
+cffi==1.15.0
+    # via
+    #   -r requirements/test.txt
+    #   pynacl
+charset-normalizer==2.0.12
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   requests
-click==8.0.3
+click==8.1.3
     # via
     #   -r requirements/pip-tools.txt
+    #   -r requirements/test.txt
+    #   edx-django-utils
     #   pip-tools
 codecov==2.1.12
     # via -r requirements/ci.txt
-coverage[toml]==6.3.1
+coverage[toml]==6.3.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -47,7 +53,7 @@ distlib==0.3.4
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.12
+django==3.2.13
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/test.txt
@@ -61,15 +67,15 @@ django-crum==0.7.9
     #   edx-django-utils
 django-storages==1.12.3
     # via -r requirements/test.txt
-django-waffle==2.3.0
+django-waffle==2.4.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-edx-django-release-util==1.1.1
+edx-django-release-util==1.2.0
     # via -r requirements/test.txt
-edx-django-utils==4.5.0
+edx-django-utils==4.8.1
     # via -r requirements/test.txt
-filelock==3.4.2
+filelock==3.7.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -87,14 +93,14 @@ iniconfig==1.1.1
     #   pytest
 isort==5.10.1
     # via -r requirements/test.txt
-jmespath==0.10.0
+jmespath==1.0.0
     # via
     #   -r requirements/test.txt
     #   boto3
     #   botocore
 mysqlclient==2.1.0
     # via -r requirements/test.txt
-newrelic==7.4.0.172
+newrelic==7.10.0.175
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -104,9 +110,9 @@ packaging==21.3
     #   -r requirements/test.txt
     #   pytest
     #   tox
-path.py==11.0.1
+path-py==11.0.1
     # via -r requirements/test.txt
-pbr==5.8.0
+pbr==5.9.0
     # via
     #   -r requirements/test.txt
     #   stevedore
@@ -114,9 +120,9 @@ pep517==0.12.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pip-tools==6.4.0
+pip-tools==6.6.1
     # via -r requirements/pip-tools.txt
-platformdirs==2.4.1
+platformdirs==2.5.2
     # via
     #   -r requirements/ci.txt
     #   virtualenv
@@ -138,12 +144,20 @@ py==1.11.0
     #   tox
 pycodestyle==2.8.0
     # via -r requirements/quality.txt
-pyparsing==3.0.7
+pycparser==2.21
+    # via
+    #   -r requirements/test.txt
+    #   cffi
+pynacl==1.5.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-django-utils
+pyparsing==3.0.9
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   packaging
-pytest==6.2.5
+pytest==7.1.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -160,10 +174,12 @@ python-memcached==1.59
     # via -r requirements/test.txt
 python-termstyle==0.1.10
     # via -r requirements/test.txt
-pytz==2021.3
+pytz==2022.1
     # via
     #   -r requirements/test.txt
     #   django
+pywatchman==1.4.1 ; "linux" in sys_platform
+    # via -r requirements/dev.in
 pyyaml==6.0
     # via
     #   -r requirements/test.txt
@@ -173,7 +189,7 @@ requests==2.27.1
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   codecov
-s3transfer==0.5.0
+s3transfer==0.5.2
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -197,28 +213,27 @@ stevedore==3.5.0
 toml==0.10.2
     # via
     #   -r requirements/ci.txt
-    #   -r requirements/test.txt
-    #   pytest
     #   tox
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/test.txt
     #   coverage
     #   pep517
-tox==3.24.5
+    #   pytest
+tox==3.25.0
     # via
     #   -r requirements/ci.txt
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.txt
-urllib3==1.26.8
+urllib3==1.26.9
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   botocore
     #   requests
-virtualenv==20.13.0
+virtualenv==20.14.1
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-click==8.0.3
+click==8.1.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.6.1
     # via -r requirements/pip-tools.in
-tomli==2.0.0
+tomli==2.0.1
     # via pep517
 wheel==0.37.1
     # via pip-tools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.1
     # via
     #   -r requirements/../requirements.txt
     #   django
 attrs==21.4.0
     # via pytest
-backoff==1.11.1
+backoff==2.0.1
     # via -r requirements/../requirements.txt
-boto3==1.20.46
+boto3==1.23.0
     # via -r requirements/../requirements.txt
-botocore==1.23.46
+botocore==1.26.0
     # via
     #   -r requirements/../requirements.txt
     #   boto3
@@ -23,11 +23,19 @@ certifi==2021.10.8
     # via
     #   -r requirements/../requirements.txt
     #   requests
-charset-normalizer==2.0.11
+cffi==1.15.0
+    # via
+    #   -r requirements/../requirements.txt
+    #   pynacl
+charset-normalizer==2.0.12
     # via
     #   -r requirements/../requirements.txt
     #   requests
-coverage[toml]==6.3.1
+click==8.1.3
+    # via
+    #   -r requirements/../requirements.txt
+    #   edx-django-utils
+coverage[toml]==6.3.3
     # via pytest-cov
     # via
     #   -c requirements/common_constraints.txt
@@ -42,13 +50,13 @@ django-crum==0.7.9
     #   edx-django-utils
 django-storages==1.12.3
     # via -r requirements/../requirements.txt
-django-waffle==2.3.0
+django-waffle==2.4.1
     # via
     #   -r requirements/../requirements.txt
     #   edx-django-utils
-edx-django-release-util==1.1.1
+edx-django-release-util==1.2.0
     # via -r requirements/../requirements.txt
-edx-django-utils==4.5.0
+edx-django-utils==4.8.1
     # via -r requirements/../requirements.txt
 gunicorn==20.1.0
     # via -r requirements/../requirements.txt
@@ -60,22 +68,22 @@ iniconfig==1.1.1
     # via pytest
 isort==5.10.1
     # via -r requirements/../requirements.txt
-jmespath==0.10.0
+jmespath==1.0.0
     # via
     #   -r requirements/../requirements.txt
     #   boto3
     #   botocore
 mysqlclient==2.1.0
     # via -r requirements/../requirements.txt
-newrelic==7.4.0.172
+newrelic==7.10.0.175
     # via
     #   -r requirements/../requirements.txt
     #   edx-django-utils
 packaging==21.3
     # via pytest
-path.py==11.0.1
+path-py==11.0.1
     # via -r requirements/../requirements.txt
-pbr==5.8.0
+pbr==5.9.0
     # via
     #   -r requirements/../requirements.txt
     #   stevedore
@@ -87,9 +95,17 @@ psutil==5.9.0
     #   edx-django-utils
 py==1.11.0
     # via pytest
-pyparsing==3.0.7
+pycparser==2.21
+    # via
+    #   -r requirements/../requirements.txt
+    #   cffi
+pynacl==1.5.0
+    # via
+    #   -r requirements/../requirements.txt
+    #   edx-django-utils
+pyparsing==3.0.9
     # via packaging
-pytest==6.2.5
+pytest==7.1.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -106,7 +122,7 @@ python-memcached==1.59
     # via -r requirements/../requirements.txt
 python-termstyle==0.1.10
     # via -r requirements/../requirements.txt
-pytz==2021.3
+pytz==2022.1
     # via
     #   -r requirements/../requirements.txt
     #   django
@@ -116,7 +132,7 @@ pyyaml==6.0
     #   edx-django-release-util
 requests==2.27.1
     # via -r requirements/../requirements.txt
-s3transfer==0.5.0
+s3transfer==0.5.2
     # via
     #   -r requirements/../requirements.txt
     #   boto3
@@ -134,11 +150,11 @@ stevedore==3.5.0
     # via
     #   -r requirements/../requirements.txt
     #   edx-django-utils
-toml==0.10.2
-    # via pytest
-tomli==2.0.0
-    # via coverage
-urllib3==1.26.8
+tomli==2.0.1
+    # via
+    #   coverage
+    #   pytest
+urllib3==1.26.9
     # via
     #   -r requirements/../requirements.txt
     #   botocore


### PR DESCRIPTION
I had to manually edit pip-tools.txt and then run `make upgrade` to get
past a pip/pip-tools incompatibility.