### PR TITLE
Convert ansible to dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.tox
+coverage
+coverage.xml
+Dockerfile
+geckodriver.log
+htmlcov

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,48 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches:
+      - master
+      - open-release/**
+jobs:
+  push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Use the release name as the image tag if we're building an open release tag.
+      # Examples: if we're building 'open-release/olive.master', tag the image as 'olive.master'.
+      # Otherwise, we must be building from a push to master, so use 'latest'.
+      - name: Get tag name
+        id: get-tag-name
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const branchName = context.ref.split('/').slice(-1)[0];
+            const tagName = branchName === 'master' ? 'latest' : branchName;
+            console.log('Will use tag: ' + tagName);
+            return tagName;
+          result-encoding: string
+
+      - name: Build and push Dev Docker image
+        uses: docker/build-push-action@v1
+        with:
+          push: true
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          target: dev
+          repository: edxops/xqueue-dev
+          tags: ${{ steps.get-tag-name.outputs.result }},${{ github.sha }}
+
+      - name: Build and push prod Docker image
+        uses: docker/build-push-action@v1
+        with:
+          push: true
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          target: production
+          repository: edxops/xqueue-prod
+          tags: ${{ steps.get-tag-name.outputs.result }},${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,71 @@
-FROM ubuntu:focal
+FROM ubuntu:focal as app
 
-RUN apt update && \
-  apt-get install -y software-properties-common && \
-  apt-add-repository -y ppa:deadsnakes/ppa && apt-get update && \
-  apt-get install git-core language-pack-en python3-pip libmysqlclient-dev ntp libssl-dev python3.8-dev python3.8-venv -qy && \
-  rm -rf /var/lib/apt/lists/*
+# System requirements
 
-ENV VIRTUAL_ENV=/venv
-RUN python3.8 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN apt-get update && \
+    apt-get upgrade -qy && apt-get install language-pack-en locales git \
+    python3.8-dev python3-virtualenv libmysqlclient-dev libssl-dev build-essential wget unzip -qy && \
+    rm -rf /var/lib/apt/lists/*
 
+# Python is Python3.
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+# Use UTF-8.
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
-RUN useradd -m --shell /bin/false app
-RUN mkdir -p /edx/app/log/
-RUN touch /edx/app/log/edx.log
-RUN chown app:app /edx/app/log/edx.log
 
-WORKDIR /edx/app/xqueue
-COPY requirements /edx/app/xqueue/requirements
-COPY requirements.txt /edx/app/xqueue/requirements.txt
-RUN pip install -r requirements.txt
+ARG COMMON_APP_DIR="/edx/app"
+ARG XQUEUE_APP_DIR="${COMMON_APP_DIR}/xqueue"
+ENV XQUEUE_APP_DIR="${COMMON_APP_DIR}/xqueue"
+ENV XQUEUE_VENV_DIR="${COMMON_APP_DIR}/xqueue/venvs/xqueue"
+ENV XQUEUE_CODE_DIR="${XQUEUE_APP_DIR}/xqueue"
 
-USER app
+ENV PATH="$XQUEUE_VENV_DIR/bin:$PATH"
 
+# Working directory will be root of repo.
+WORKDIR ${XQUEUE_CODE_DIR}
+
+RUN virtualenv -p python3.8 --always-copy ${XQUEUE_VENV_DIR}
+
+# Copy just Python requirements & install them.
+COPY requirements ${XQUEUE_CODE_DIR}/requirements
+COPY requirements.txt ${XQUEUE_APP_DIR}/requirements.txt
+COPY Makefile ${XQUEUE_CODE_DIR}
+
+# placeholder file for the time being unless devstack provisioning scripts need it.
+RUN touch ${XQUEUE_APP_DIR}/xqueue_env
+
+# Expose ports.
 EXPOSE 8040
-CMD gunicorn -c /edx/app/xqueue/xqueue/docker_gunicorn_configuration.py --bind=0.0.0.0:8040 --workers 2 --max-requests=1000 xqueue.wsgi:application
 
-COPY . /edx/app/xqueue
+FROM app as dev
+
+# xqueue service config commands below
+RUN pip install -r ${XQUEUE_CODE_DIR}/requirements/dev.txt
+
+# After the requirements so changes to the code will not bust the image cache
+COPY . ${XQUEUE_CODE_DIR}/
+
+ENV DJANGO_SETTINGS_MODULE xqueue.devstack
+
+CMD while true; do python ./manage.py runserver 0.0.0.0:8040; sleep 2; done
+
+FROM app as production
+
+# xqueue service config commands below
+RUN pip install -r ${XQUEUE_APP_DIR}/requirements.txt
+
+# After the requirements so changes to the code will not bust the image cache
+COPY . ${XQUEUE_CODE_DIR}/
+
+ENV DJANGO_SETTINGS_MODULE xqueue.production
+
+CMD gunicorn \
+    --pythonpath=/edx/app/xqueue/xqueue \
+    --timeout=300 \
+    -b 0.0.0.0:8040 \
+    -w 2 \
+    - xqueue.wsgi:application


### PR DESCRIPTION
Related devstack PR: https://github.com/openedx/devstack/pull/1006

ISSUE: https://github.com/openedx/xqueue/issues/861
This PR is part of an effort aimed at removing Ansible-based configurations and replacing them with `Dockerfile`. Currently, Devstack Docker images are built using `Ansible-based configurations` in the `configurations` repository. Through this effort, we will make sure that the Repo has its own `Dockerfile` which has all the necessary configurations to set up small production and dev environments.

**Steps to run this Image with Devstack:**

- Build the Image locally first using the target `dev` i.e. `docker build -t image-name-of-choice --target dev .`
- After the image is built successfully go to the `docker compose` file of `devstack` and replace the existing `xqueue` image with the one that you built without changing any other configurations there.
- Run `make dev.up.xqueue` in the terminal while in the devstack directory.
- Additional Note: If you face any auth related errors or 500 while accessing xqueue, then also run provisioning for `xqueue` 
