### PR TITLE
build: Remove yanked codecov package (and coverage upload)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,3 @@ jobs:
       run: |
         docker exec xqueue bash -c "cd /edx/app/xqueue/xqueue/; pip3 install -r requirements/ci.txt"
         docker exec xqueue bash -c "cd /edx/app/xqueue/xqueue/ && DB_HOST=${{ matrix.db-version }} tox -e ${TOXENV}"
-
-    - name: Code Coverage
-      if: matrix.tox-env=='django32'
-      run: |
-        python3.8 -m pip install -r requirements/ci.txt &&
-        docker exec xqueue bash -c "cd /edx/app/xqueue/xqueue/; coverage xml" && codecov

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,6 +1,5 @@
 # Requirements for running tests in Github CI
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,22 +4,12 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
-coverage==7.2.1
-    # via codecov
 distlib==0.3.6
     # via virtualenv
 filelock==3.9.1
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
 packaging==23.0
     # via tox
 platformdirs==3.1.1
@@ -28,8 +18,6 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -41,7 +29,5 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.15
-    # via requests
 virtualenv==20.21.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -27,7 +27,6 @@ build==0.10.0
     #   pip-tools
 certifi==2022.12.7
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   requests
 cffi==1.15.1
@@ -36,7 +35,6 @@ cffi==1.15.1
     #   pynacl
 charset-normalizer==3.1.0
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   requests
 click==8.1.3
@@ -45,13 +43,9 @@ click==8.1.3
     #   -r requirements/test.txt
     #   edx-django-utils
     #   pip-tools
-codecov==2.1.12
-    # via -r requirements/ci.txt
 coverage[toml]==7.2.1
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/test.txt
-    #   codecov
     #   pytest-cov
 distlib==0.3.6
     # via
@@ -92,7 +86,6 @@ gunicorn==20.1.0
     # via -r requirements/test.txt
 idna==3.4
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   requests
 iniconfig==2.0.0
@@ -188,10 +181,7 @@ pyyaml==6.0
     #   -r requirements/test.txt
     #   edx-django-release-util
 requests==2.28.2
-    # via
-    #   -r requirements/ci.txt
-    #   -r requirements/test.txt
-    #   codecov
+    # via -r requirements/test.txt
 s3transfer==0.6.0
     # via
     #   -r requirements/test.txt
@@ -231,7 +221,6 @@ tox-battery==0.6.1
     # via -r requirements/ci.txt
 urllib3==1.26.15
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   botocore
     #   requests


### PR DESCRIPTION
Stop trying to install the deprecated (and now yanked) codecov package. Also remove the CI step that was trying to use it, since we'd prefer to unblock CI now and restore coverage later. https://github.com/openedx/xqueue/issues/887 tracks restoring coverage testing.