### PR TITLE
fix: Actually install pip.txt when installing requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ quality: ## check coding style with pycodestyle and pylint
 	isort --recursive --check-only submission_queue/ xqueue/
 
 requirements: ## install development environment requirements
+	pip install -qr requirements/pip.txt
 	pip install -qr requirements/pip-tools.txt --exists-action w
 	pip-sync requirements/dev.txt requirements/private.*
 


### PR DESCRIPTION
We were creating pip.txt but not using it, which eventually leads to errors when pip-tools falls out of sync with the system pip.