### PR TITLE
Backport Django 4.2 upgrade in Quince

### DIFF
--- a/.github/docker-compose-ci.yml
+++ b/.github/docker-compose-ci.yml
@@ -19,7 +19,7 @@ services:
 
   xqueue:
     container_name: xqueue
-    image: edxops/xqueue:latest
+    image: edxops/xqueue-dev:latest
     command: tail -f /dev/null
     volumes:
       - ..:/edx/app/xqueue/xqueue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,9 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        tox-env: [quality, django32, django42]
+        tox-env: [quality, django42]
         python-version: [3.8]
-        db-version: ['mysql57', 'mysql80']
-        # excluding mysql5.7 with Django 4.2 since Django 4.2 has 
-        # dropped support for MySQL<8
-        exclude:
-          - tox-env: 'django42'
-            db-version: 'mysql57'
+        db-version: ['mysql80']
 
     steps:
     - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ $(COMMON_CONSTRAINTS_TXT):
 
 export CUSTOM_COMPILE_COMMAND = make upgrade
 upgrade: $(COMMON_CONSTRAINTS_TXT) ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
-	sed 's/Django<2.3//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
+	sed 's/Django<4.0//g' requirements/common_constraints.txt > requirements/common_constraints.tmp
 	mv requirements/common_constraints.tmp requirements/common_constraints.txt
 	pip install -qr requirements/pip-tools.txt
 	# Make sure to compile files after any other files they include!

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,43 +4,44 @@
 #
 #    make upgrade
 #
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
 backoff==2.2.1
     # via -r requirements/base.in
-boto3==1.26.91
+backports-zoneinfo==0.2.1
+    # via django
+boto3==1.28.54
     # via -r requirements/base.in
-botocore==1.29.91
+botocore==1.31.54
     # via
     #   boto3
     #   s3transfer
-certifi==2022.12.7
+certifi==2023.7.22
     # via requests
 cffi==1.15.1
     # via pynacl
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
-click==8.1.3
+click==8.1.7
     # via edx-django-utils
-django==3.2.20
+django==4.2.5
     # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/base.in
     #   django-crum
     #   django-storages
+    #   django-waffle
     #   edx-django-release-util
     #   edx-django-utils
 django-crum==0.7.9
     # via edx-django-utils
-django-storages==1.13.2
+django-storages==1.14
     # via -r requirements/base.in
-django-waffle==3.0.0
+django-waffle==4.0.0
     # via edx-django-utils
-edx-django-release-util==1.2.0
+edx-django-release-util==1.3.0
     # via -r requirements/base.in
-edx-django-utils==5.2.0
+edx-django-utils==5.7.0
     # via -r requirements/base.in
-gunicorn==20.1.0
+gunicorn==21.2.0
     # via -r requirements/base.in
 idna==3.4
     # via requests
@@ -50,17 +51,19 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-mysqlclient==2.1.1
+mysqlclient==2.2.0
     # via -r requirements/base.in
-newrelic==8.7.0
+newrelic==9.1.0
     # via
     #   -r requirements/base.in
     #   edx-django-utils
+packaging==23.1
+    # via gunicorn
 path-py==11.0.1
     # via -r requirements/base.in
 pbr==5.11.1
     # via stevedore
-psutil==5.9.4
+psutil==5.9.5
     # via edx-django-utils
 pycparser==2.21
     # via cffi
@@ -72,26 +75,26 @@ python-memcached==1.59
     # via -r requirements/base.in
 python-termstyle==0.1.10
     # via -r requirements/base.in
-pytz==2022.7.1
-    # via
-    #   -r requirements/base.in
-    #   django
-pyyaml==6.0
-    # via edx-django-release-util
-requests==2.28.2
+pytz==2023.3.post1
     # via -r requirements/base.in
-s3transfer==0.6.0
+pyyaml==6.0.1
+    # via edx-django-release-util
+requests==2.31.0
+    # via -r requirements/base.in
+s3transfer==0.6.2
     # via boto3
 six==1.16.0
     # via
     #   edx-django-release-util
     #   python-dateutil
     #   python-memcached
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
-stevedore==5.0.0
+stevedore==5.1.0
     # via edx-django-utils
-urllib3==1.26.15
+typing-extensions==4.8.0
+    # via asgiref
+urllib3==1.26.16
     # via
     #   botocore
     #   requests

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,7 +4,7 @@
 mysqlclient
 backoff
 boto3
-Django<4
+Django
 django-storages
 edx-django-release-util
 edx-django-utils

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-distlib==0.3.6
+distlib==0.3.7
     # via virtualenv
-filelock==3.9.1
+filelock==3.12.4
     # via
     #   tox
     #   virtualenv
-packaging==23.0
+packaging==23.1
     # via tox
-platformdirs==3.1.1
+platformdirs==3.10.0
     # via virtualenv
-pluggy==1.0.0
+pluggy==1.3.0
     # via tox
 py==1.11.0
     # via tox
@@ -27,7 +27,7 @@ tox==3.28.0
     #   -c requirements/common_constraints.txt
     #   -r requirements/ci.in
     #   tox-battery
-tox-battery==0.6.1
+tox-battery==0.6.2
     # via -r requirements/ci.in
-virtualenv==20.21.0
+virtualenv==20.24.5
     # via tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -18,7 +18,7 @@
 
 
 # using LTS django version
-Django<4.0
+
 
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
@@ -30,8 +30,3 @@ django-simple-history==3.0.0
 # tox>4.0.0 isn't yet compatible with many tox plugins, causing CI failures in almost all repos.
 # Details can be found in this discussion: https://github.com/tox-dev/tox/discussions/1810
 tox<4.0.0
-
-# edx-sphinx-theme is not compatible with latest Sphinx==6.0.0 version 
-# Pinning Sphinx version unless the compatibility issue gets resolved
-# For details, see issue https://github.com/openedx/edx-sphinx-theme/issues/197
-sphinx<6.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,28 +4,28 @@
 #
 #    make upgrade
 #
-asgiref==3.6.0
+asgiref==3.7.2
     # via
     #   -r requirements/test.txt
     #   django
-attrs==22.2.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 backoff==2.2.1
     # via -r requirements/test.txt
-boto3==1.26.91
+backports-zoneinfo==0.2.1
+    # via
+    #   -r requirements/test.txt
+    #   django
+boto3==1.28.54
     # via -r requirements/test.txt
-botocore==1.29.91
+botocore==1.31.54
     # via
     #   -r requirements/test.txt
     #   boto3
     #   s3transfer
-build==0.10.0
+build==1.0.3
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-certifi==2022.12.7
+certifi==2023.7.22
     # via
     #   -r requirements/test.txt
     #   requests
@@ -33,61 +33,65 @@ cffi==1.15.1
     # via
     #   -r requirements/test.txt
     #   pynacl
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via
     #   -r requirements/test.txt
     #   requests
-click==8.1.3
+click==8.1.7
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/test.txt
     #   edx-django-utils
     #   pip-tools
-coverage[toml]==7.2.1
+coverage[toml]==7.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-distlib==0.3.6
+distlib==0.3.7
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.20
+django==4.2.5
     # via
-    #   -c requirements/common_constraints.txt
     #   -r requirements/test.txt
     #   django-crum
     #   django-storages
+    #   django-waffle
     #   edx-django-release-util
     #   edx-django-utils
 django-crum==0.7.9
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-django-storages==1.13.2
+django-storages==1.14
     # via -r requirements/test.txt
-django-waffle==3.0.0
+django-waffle==4.0.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-edx-django-release-util==1.2.0
+edx-django-release-util==1.3.0
     # via -r requirements/test.txt
-edx-django-utils==5.2.0
+edx-django-utils==5.7.0
     # via -r requirements/test.txt
-exceptiongroup==1.1.1
+exceptiongroup==1.1.3
     # via
     #   -r requirements/test.txt
     #   pytest
-filelock==3.9.1
+filelock==3.12.4
     # via
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
-gunicorn==20.1.0
+gunicorn==21.2.0
     # via -r requirements/test.txt
 idna==3.4
     # via
     #   -r requirements/test.txt
     #   requests
+importlib-metadata==6.8.0
+    # via
+    #   -r requirements/pip-tools.txt
+    #   build
 iniconfig==2.0.0
     # via
     #   -r requirements/test.txt
@@ -99,18 +103,19 @@ jmespath==1.0.1
     #   -r requirements/test.txt
     #   boto3
     #   botocore
-mysqlclient==2.1.1
+mysqlclient==2.2.0
     # via -r requirements/test.txt
-newrelic==8.7.0
+newrelic==9.1.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/test.txt
     #   build
+    #   gunicorn
     #   pytest
     #   tox
 path-py==11.0.1
@@ -119,19 +124,19 @@ pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-pip-tools==6.12.3
+pip-tools==7.3.0
     # via -r requirements/pip-tools.txt
-platformdirs==3.1.1
+platformdirs==3.10.0
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-pluggy==1.0.0
+pluggy==1.3.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   pytest
     #   tox
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -139,7 +144,7 @@ py==1.11.0
     # via
     #   -r requirements/ci.txt
     #   tox
-pycodestyle==2.10.0
+pycodestyle==2.11.0
     # via -r requirements/quality.txt
 pycparser==2.21
     # via
@@ -153,12 +158,12 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pytest==7.2.2
+pytest==7.4.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.txt
 pytest-django==4.5.2
     # via -r requirements/test.txt
@@ -170,19 +175,17 @@ python-memcached==1.59
     # via -r requirements/test.txt
 python-termstyle==0.1.10
     # via -r requirements/test.txt
-pytz==2022.7.1
-    # via
-    #   -r requirements/test.txt
-    #   django
+pytz==2023.3.post1
+    # via -r requirements/test.txt
 pywatchman==1.4.1 ; "linux" in sys_platform
     # via -r requirements/dev.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r requirements/test.txt
     #   edx-django-release-util
-requests==2.28.2
+requests==2.31.0
     # via -r requirements/test.txt
-s3transfer==0.6.0
+s3transfer==0.6.2
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -194,11 +197,11 @@ six==1.16.0
     #   python-dateutil
     #   python-memcached
     #   tox
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -209,6 +212,7 @@ tomli==2.0.1
     #   -r requirements/test.txt
     #   build
     #   coverage
+    #   pip-tools
     #   pyproject-hooks
     #   pytest
     #   tox
@@ -217,21 +221,29 @@ tox==3.28.0
     #   -c requirements/common_constraints.txt
     #   -r requirements/ci.txt
     #   tox-battery
-tox-battery==0.6.1
+tox-battery==0.6.2
     # via -r requirements/ci.txt
-urllib3==1.26.15
+typing-extensions==4.8.0
+    # via
+    #   -r requirements/test.txt
+    #   asgiref
+urllib3==1.26.16
     # via
     #   -r requirements/test.txt
     #   botocore
     #   requests
-virtualenv==20.21.0
+virtualenv==20.24.5
     # via
     #   -r requirements/ci.txt
     #   tox
-wheel==0.40.0
+wheel==0.41.2
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
+zipp==3.17.0
+    # via
+    #   -r requirements/pip-tools.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,20 +4,27 @@
 #
 #    make upgrade
 #
-build==0.10.0
+build==1.0.3
     # via pip-tools
-click==8.1.3
+click==8.1.7
     # via pip-tools
-packaging==23.0
+importlib-metadata==6.8.0
     # via build
-pip-tools==6.12.3
+packaging==23.1
+    # via build
+pip-tools==7.3.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build
 tomli==2.0.1
-    # via build
-wheel==0.40.0
+    # via
+    #   build
+    #   pip-tools
+    #   pyproject-hooks
+wheel==0.41.2
     # via pip-tools
+zipp==3.17.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.40.0
+wheel==0.41.2
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.0.1
+pip==23.2.1
     # via -r requirements/pip.in
-setuptools==67.6.0
+setuptools==68.2.2
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,5 +4,5 @@
 #
 #    make upgrade
 #
-pycodestyle==2.10.0
+pycodestyle==2.11.0
     # via -r requirements/quality.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,22 +4,24 @@
 #
 #    make upgrade
 #
-asgiref==3.6.0
+asgiref==3.7.2
     # via
     #   -r requirements/../requirements.txt
     #   django
-attrs==22.2.0
-    # via pytest
 backoff==2.2.1
     # via -r requirements/../requirements.txt
-boto3==1.26.91
+backports-zoneinfo==0.2.1
+    # via
+    #   -r requirements/../requirements.txt
+    #   django
+boto3==1.28.54
     # via -r requirements/../requirements.txt
-botocore==1.29.91
+botocore==1.31.54
     # via
     #   -r requirements/../requirements.txt
     #   boto3
     #   s3transfer
-certifi==2022.12.7
+certifi==2023.7.22
     # via
     #   -r requirements/../requirements.txt
     #   requests
@@ -27,40 +29,40 @@ cffi==1.15.1
     # via
     #   -r requirements/../requirements.txt
     #   pynacl
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via
     #   -r requirements/../requirements.txt
     #   requests
-click==8.1.3
+click==8.1.7
     # via
     #   -r requirements/../requirements.txt
     #   edx-django-utils
-coverage[toml]==7.2.1
+coverage[toml]==7.3.1
     # via pytest-cov
     # via
-    #   -c requirements/common_constraints.txt
     #   -r requirements/../requirements.txt
     #   django-crum
     #   django-storages
+    #   django-waffle
     #   edx-django-release-util
     #   edx-django-utils
 django-crum==0.7.9
     # via
     #   -r requirements/../requirements.txt
     #   edx-django-utils
-django-storages==1.13.2
+django-storages==1.14
     # via -r requirements/../requirements.txt
-django-waffle==3.0.0
+django-waffle==4.0.0
     # via
     #   -r requirements/../requirements.txt
     #   edx-django-utils
-edx-django-release-util==1.2.0
+edx-django-release-util==1.3.0
     # via -r requirements/../requirements.txt
-edx-django-utils==5.2.0
+edx-django-utils==5.7.0
     # via -r requirements/../requirements.txt
-exceptiongroup==1.1.1
+exceptiongroup==1.1.3
     # via pytest
-gunicorn==20.1.0
+gunicorn==21.2.0
     # via -r requirements/../requirements.txt
 idna==3.4
     # via
@@ -75,23 +77,26 @@ jmespath==1.0.1
     #   -r requirements/../requirements.txt
     #   boto3
     #   botocore
-mysqlclient==2.1.1
+mysqlclient==2.2.0
     # via -r requirements/../requirements.txt
-newrelic==8.7.0
+newrelic==9.1.0
     # via
     #   -r requirements/../requirements.txt
     #   edx-django-utils
-packaging==23.0
-    # via pytest
+packaging==23.1
+    # via
+    #   -r requirements/../requirements.txt
+    #   gunicorn
+    #   pytest
 path-py==11.0.1
     # via -r requirements/../requirements.txt
 pbr==5.11.1
     # via
     #   -r requirements/../requirements.txt
     #   stevedore
-pluggy==1.0.0
+pluggy==1.3.0
     # via pytest
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   -r requirements/../requirements.txt
     #   edx-django-utils
@@ -103,12 +108,12 @@ pynacl==1.5.0
     # via
     #   -r requirements/../requirements.txt
     #   edx-django-utils
-pytest==7.2.2
+pytest==7.4.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.in
 pytest-django==4.5.2
     # via -r requirements/test.in
@@ -120,17 +125,15 @@ python-memcached==1.59
     # via -r requirements/../requirements.txt
 python-termstyle==0.1.10
     # via -r requirements/../requirements.txt
-pytz==2022.7.1
-    # via
-    #   -r requirements/../requirements.txt
-    #   django
-pyyaml==6.0
+pytz==2023.3.post1
+    # via -r requirements/../requirements.txt
+pyyaml==6.0.1
     # via
     #   -r requirements/../requirements.txt
     #   edx-django-release-util
-requests==2.28.2
+requests==2.31.0
     # via -r requirements/../requirements.txt
-s3transfer==0.6.0
+s3transfer==0.6.2
     # via
     #   -r requirements/../requirements.txt
     #   boto3
@@ -140,17 +143,23 @@ six==1.16.0
     #   edx-django-release-util
     #   python-dateutil
     #   python-memcached
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/../requirements.txt
     #   django
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   -r requirements/../requirements.txt
     #   edx-django-utils
 tomli==2.0.1
-    # via pytest
-urllib3==1.26.15
+    # via
+    #   coverage
+    #   pytest
+typing-extensions==4.8.0
+    # via
+    #   -r requirements/../requirements.txt
+    #   asgiref
+urllib3==1.26.16
     # via
     #   -r requirements/../requirements.txt
     #   botocore

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-django{32, 42},quality
+envlist = py38-django{42},quality
 skipsdist = True
 
 [pycodestyle]
@@ -13,7 +13,6 @@ norecursedirs = .* jenkins load_tests log reports script test_framework xqueue
 
 [testenv]
 deps = 
-    django32: Django>=3.2,<4.0
     django42: Django>=4.2,<4.3
     -r{toxinidir}/requirements/test.txt
 passenv = 

--- a/xqueue/settings.py
+++ b/xqueue/settings.py
@@ -78,6 +78,11 @@ USE_L10N = True
 # If you set this to False, Django will not use timezone-aware datetimes.
 USE_TZ = True
 
+# Django 4.0+ uses zoneinfo if this is not set. We can remove this and
+# migrate to zoneinfo after Django 4.2 upgrade. See more on following url
+# https://docs.djangoproject.com/en/4.2/releases/4.0/#zoneinfo-default-timezone-implementation
+USE_DEPRECATED_PYTZ = True
+
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: "/home/media/media.lawrence.com/media/"
 MEDIA_ROOT = ''
@@ -89,8 +94,6 @@ MEDIA_URL = ''
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'uofqkujp@z#_vtwct+v716z+^3hijelj1^fkydwo2^pbkxghfq'
-
-DEFAULT_HASHING_ALGORITHM = "sha1"
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 


### PR DESCRIPTION
Upgrade Django to 4.2 LTS

Bacporting this commit https://github.com/openedx/xqueue/commit/3230bd6f114b087955b8a52740e030bac64e2638 to quince.master.