### PR TITLE
fix: backport codecov removal to Palm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,3 @@ jobs:
       run: |
         docker exec xqueue bash -c "cd /edx/app/xqueue/xqueue/; pip3 install -r requirements/ci.txt"
         docker exec xqueue bash -c "cd /edx/app/xqueue/xqueue/ && DB_HOST=${{ matrix.db-version }} tox -e ${TOXENV}"
-
-    - name: Code Coverage
-      if: matrix.tox-env=='django32'
-      run: |
-        python3.8 -m pip install -r requirements/ci.txt &&
-        docker exec xqueue bash -c "cd /edx/app/xqueue/xqueue/; coverage xml" && codecov

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,6 +1,5 @@
 # Requirements for running tests in Github CI
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,10 +8,6 @@ certifi==2022.12.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
-coverage==7.2.1
-    # via codecov
 distlib==0.3.6
     # via virtualenv
 filelock==3.9.1
@@ -28,8 +24,6 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -45,13 +45,10 @@ click==8.1.3
     #   -r requirements/test.txt
     #   edx-django-utils
     #   pip-tools
-codecov==2.1.12
-    # via -r requirements/ci.txt
 coverage[toml]==7.2.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
-    #   codecov
     #   pytest-cov
 distlib==0.3.6
     # via
@@ -191,7 +188,6 @@ requests==2.28.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
-    #   codecov
 s3transfer==0.6.0
     # via
     #   -r requirements/test.txt


### PR DESCRIPTION
This is backporting https://github.com/openedx/xqueue/commit/592888dd8a20cdbfef8ce934c301e5234e9f2a09 to Palm branch