### PR TITLE
chore: update Django to 4.2.11 for Quince - Security Patch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ charset-normalizer==3.2.0
     # via requests
 click==8.1.7
     # via edx-django-utils
-django==4.2.10
+django==4.2.11
     # via
     #   django-crum
     #   django-storages

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -51,7 +51,7 @@ distlib==0.3.7
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==4.2.10
+django==4.2.11
     # via
     #   -r requirements/test.txt
     #   django-crum


### PR DESCRIPTION
See: https://github.com/openedx/wg-build-test-release/issues/341