### PR TITLE
fix: Replace default secret key with placeholder

### DIFF
--- a/xqueue/settings.py
+++ b/xqueue/settings.py
@@ -93,7 +93,7 @@ MEDIA_ROOT = ''
 MEDIA_URL = ''
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = 'uofqkujp@z#_vtwct+v716z+^3hijelj1^fkydwo2^pbkxghfq'
+SECRET_KEY = '[PLACEHOLDER]'
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 


### PR DESCRIPTION
This makes it clear that the field is unused and should be overridden.