### PR TITLE
build: Simplify xqueue test setup.

### DIFF
--- a/.github/docker-compose-ci.yml
+++ b/.github/docker-compose-ci.yml
@@ -8,14 +8,5 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ""
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-
-  xqueue:
-    container_name: xqueue
-    image: edxops/xqueue-dev:latest
-    command: tail -f /dev/null
-    volumes:
-      - ..:/edx/app/xqueue/xqueue
-    depends_on:
-      - mysql80
-    environment:
-      RABBIT_HOST: "rabbit"
+    ports:
+      - "3306:3306"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['py311', 'py312']
+        python-version:
+        - "3.11"
+        - "3.12"
         env-name: ['django42','django52', 'quality']
         db-version: ['mysql80']
 
@@ -24,23 +26,14 @@ jobs:
       run: |
         docker compose -f .github/docker-compose-ci.yml up -d
 
-    - name: Setup Python ${{ matrix.python-version }} inside container
-      run: |
-        PY_VER=$(if [ "${{ matrix.python-version }}" = "py312" ]; then echo "3.12"; else echo "3.11"; fi)
-
-        docker exec xqueue bash -c "
-          apt update &&
-          apt install -y software-properties-common curl &&
-          add-apt-repository ppa:deadsnakes/ppa -y &&
-          apt install -y python$PY_VER python$PY_VER-dev python$PY_VER-venv &&
-          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python$PY_VER 1 &&
-          python$PY_VER -m venv /tmp/venv &&
-          /tmp/venv/bin/pip install --upgrade pip
-        "
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Install test dependencies and run tests
       env:
-        TOXENV: ${{ matrix.python-version }}-${{ matrix.env-name }}
+        TOXENV: ${{ matrix.env-name }}
       run: |
-        docker exec xqueue bash -c "cd /edx/app/xqueue/xqueue/; /tmp/venv/bin/pip install -r requirements/ci.txt"
-        docker exec xqueue bash -c "cd /edx/app/xqueue/xqueue/ && DB_HOST=${{ matrix.db-version }} tox -e ${TOXENV}"
+        pip install -r requirements/ci.txt
+        tox -e ${TOXENV}

--- a/xqueue/test_settings.py
+++ b/xqueue/test_settings.py
@@ -17,11 +17,11 @@ LOGGING = get_logger_config(log_dir,
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'USER': os.environ.get('DB_USER', ''),
+        'USER': os.environ.get('DB_USER', 'root'),
         'PASSWORD': os.environ.get('DB_PASSWORD', ''),
         # pytest/django TestCase instances auto-prefix test_ onto the NAME
         'NAME': 'xqueue',
-        'HOST': os.environ.get('DB_HOST', 'edx.devstack.mysql80'),
+        'HOST': '127.0.0.1',
         # Wrap all view methods in an atomic transaction automatically.
         'ATOMIC_REQUESTS': True
     }


### PR DESCRIPTION
Previously we tested inside an outdated xqueue container but that
container no longer gets updates and so that strategy is out of date.
We update the tests to just test locally using github's capabilities to
manage the python version.

We could also use it to manage mysql and that's a future improvement we
can make but for now this should unblock the tests working again.  I'm
aiming to do the minimal necessary to fix the tests since this repo is
deprecated and will go away within the next year.
