### PR TITLE
docs: Update DEPR date

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 ⛔️ WARNING
 ==========
 
-This repository is under-maintained. We are not fixing bugs or developing new features for it. We hope to deprecate it officially in October of 2024. For updates, `follow along on the DEPR ticket <https://github.com/openedx/public-engineering/issues/286>`_.
+This repository is under-maintained. We are not fixing bugs or developing new features for it. We will officially deprecate it in April of 2026. For updates, `follow along on the DEPR ticket <https://github.com/openedx/public-engineering/issues/286>`_.
 
 Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to security@openedx.org
 


### PR DESCRIPTION
Per https://github.com/openedx/public-engineering/issues/286, we will be DEPR'ing this repo in or after April of 2026.