### PR TITLE
fix: django util version upgraded to 8.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,21 +8,21 @@ asgiref==3.11.1
     # via django
 backoff==2.2.1
     # via -r requirements/base.in
-boto3==1.42.84
+boto3==1.43.9
     # via -r requirements/base.in
-botocore==1.42.84
+botocore==1.43.9
     # via
     #   boto3
     #   s3transfer
-certifi==2026.2.25
+certifi==2026.4.22
     # via requests
 cffi==2.0.0
     # via pynacl
 charset-normalizer==3.4.7
     # via requests
-click==8.3.2
+click==8.4.0
     # via edx-django-utils
-django==5.2.13
+django==5.2.14
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
@@ -41,9 +41,9 @@ edx-django-release-util==1.5.0
     # via -r requirements/base.in
 edx-django-utils==8.0.1
     # via -r requirements/base.in
-gunicorn==25.3.0
+gunicorn==26.0.0
     # via -r requirements/base.in
-idna==3.11
+idna==3.15
     # via requests
 isort==8.0.1
     # via -r requirements/base.in
@@ -53,9 +53,9 @@ jmespath==1.1.0
     #   botocore
 mysqlclient==2.2.8
     # via -r requirements/base.in
-newrelic==12.1.0
+newrelic==13.0.0
     # via -r requirements/base.in
-packaging==26.0
+packaging==26.2
     # via gunicorn
 path==17.1.1
     # via -r requirements/base.in
@@ -71,9 +71,9 @@ python-memcached==1.62
     # via -r requirements/base.in
 pyyaml==6.0.3
     # via edx-django-release-util
-requests==2.33.1
+requests==2.34.2
     # via -r requirements/base.in
-s3transfer==0.16.0
+s3transfer==0.17.0
     # via boto3
 six==1.17.0
     # via
@@ -81,9 +81,9 @@ six==1.17.0
     #   python-dateutil
 sqlparse==0.5.5
     # via django
-stevedore==5.7.0
+stevedore==5.8.0
     # via edx-django-utils
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   requests

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,7 +7,7 @@ boto3
 Django
 django-storages
 edx-django-release-util
-edx-django-utils
+edx-django-utils>=8.0.1
 gunicorn
 isort
 newrelic

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,22 +4,22 @@
 #
 #    make upgrade
 #
-cachetools==7.0.5
+cachetools==7.1.2
     # via tox
 colorama==0.4.6
     # via tox
 distlib==0.4.0
     # via virtualenv
-filelock==3.25.2
+filelock==3.29.0
     # via
     #   python-discovery
     #   tox
     #   virtualenv
-packaging==26.0
+packaging==26.2
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   python-discovery
     #   tox
@@ -28,13 +28,13 @@ pluggy==1.6.0
     # via tox
 pyproject-api==1.10.0
     # via tox
-python-discovery==1.2.1
+python-discovery==1.3.1
     # via
     #   tox
     #   virtualenv
 tomli-w==1.2.0
     # via tox
-tox==4.52.0
+tox==4.54.0
     # via -r requirements/ci.in
-virtualenv==21.2.0
+virtualenv==21.3.3
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,22 +10,22 @@ asgiref==3.11.1
     #   django
 backoff==2.2.1
     # via -r requirements/test.txt
-boto3==1.42.84
+boto3==1.43.9
     # via -r requirements/test.txt
-botocore==1.42.84
+botocore==1.43.9
     # via
     #   -r requirements/test.txt
     #   boto3
     #   s3transfer
-build==1.4.2
+build==1.5.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==7.0.5
+cachetools==7.1.2
     # via
     #   -r requirements/ci.txt
     #   tox
-certifi==2026.2.25
+certifi==2026.4.22
     # via
     #   -r requirements/test.txt
     #   requests
@@ -37,7 +37,7 @@ charset-normalizer==3.4.7
     # via
     #   -r requirements/test.txt
     #   requests
-click==8.3.2
+click==8.4.0
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/test.txt
@@ -47,7 +47,7 @@ colorama==0.4.6
     # via
     #   -r requirements/ci.txt
     #   tox
-coverage[toml]==7.13.5
+coverage[toml]==7.14.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -55,7 +55,7 @@ distlib==0.4.0
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==5.2.13
+django==5.2.14
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/test.txt
@@ -78,15 +78,15 @@ edx-django-release-util==1.5.0
     # via -r requirements/test.txt
 edx-django-utils==8.0.1
     # via -r requirements/test.txt
-filelock==3.25.2
+filelock==3.29.0
     # via
     #   -r requirements/ci.txt
     #   python-discovery
     #   tox
     #   virtualenv
-gunicorn==25.3.0
+gunicorn==26.0.0
     # via -r requirements/test.txt
-idna==3.11
+idna==3.15
     # via
     #   -r requirements/test.txt
     #   requests
@@ -103,9 +103,9 @@ jmespath==1.1.0
     #   botocore
 mysqlclient==2.2.8
     # via -r requirements/test.txt
-newrelic==12.1.0
+newrelic==13.0.0
     # via -r requirements/test.txt
-packaging==26.0
+packaging==26.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -120,7 +120,7 @@ path==17.1.1
     # via -r requirements/test.txt
 pip-tools==7.5.3
     # via -r requirements/pip-tools.txt
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   -r requirements/ci.txt
     #   python-discovery
@@ -160,7 +160,7 @@ pyproject-hooks==1.2.0
     #   -r requirements/pip-tools.txt
     #   build
     #   pip-tools
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -173,7 +173,7 @@ python-dateutil==2.9.0.post0
     # via
     #   -r requirements/test.txt
     #   botocore
-python-discovery==1.2.1
+python-discovery==1.3.1
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -186,9 +186,9 @@ pyyaml==6.0.3
     # via
     #   -r requirements/test.txt
     #   edx-django-release-util
-requests==2.33.1
+requests==2.34.2
     # via -r requirements/test.txt
-s3transfer==0.16.0
+s3transfer==0.17.0
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -201,7 +201,7 @@ sqlparse==0.5.5
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.7.0
+stevedore==5.8.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -209,18 +209,18 @@ tomli-w==1.2.0
     # via
     #   -r requirements/ci.txt
     #   tox
-tox==4.52.0
+tox==4.54.0
     # via -r requirements/ci.txt
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/test.txt
     #   botocore
     #   requests
-virtualenv==21.2.0
+virtualenv==21.3.3
     # via
     #   -r requirements/ci.txt
     #   tox
-wheel==0.46.3
+wheel==0.47.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-build==1.4.2
+build==1.5.0
     # via pip-tools
-click==8.3.2
+click==8.4.0
     # via pip-tools
-packaging==26.0
+packaging==26.2
     # via
     #   build
     #   wheel
@@ -18,7 +18,7 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-wheel==0.46.3
+wheel==0.47.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-packaging==26.0
+packaging==26.2
     # via wheel
-wheel==0.46.3
+wheel==0.47.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.0.1
+pip==26.1.1
     # via -r requirements/pip.in
 setuptools==82.0.1
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,14 +10,14 @@ asgiref==3.11.1
     #   django
 backoff==2.2.1
     # via -r requirements.txt
-boto3==1.42.84
+boto3==1.43.9
     # via -r requirements.txt
-botocore==1.42.84
+botocore==1.43.9
     # via
     #   -r requirements.txt
     #   boto3
     #   s3transfer
-certifi==2026.2.25
+certifi==2026.4.22
     # via
     #   -r requirements.txt
     #   requests
@@ -29,11 +29,11 @@ charset-normalizer==3.4.7
     # via
     #   -r requirements.txt
     #   requests
-click==8.3.2
+click==8.4.0
     # via
     #   -r requirements.txt
     #   edx-django-utils
-coverage[toml]==7.13.5
+coverage[toml]==7.14.0
     # via pytest-cov
     # via
     #   -c requirements/common_constraints.txt
@@ -57,9 +57,9 @@ edx-django-release-util==1.5.0
     # via -r requirements.txt
 edx-django-utils==8.0.1
     # via -r requirements.txt
-gunicorn==25.3.0
+gunicorn==26.0.0
     # via -r requirements.txt
-idna==3.11
+idna==3.15
     # via
     #   -r requirements.txt
     #   requests
@@ -74,9 +74,9 @@ jmespath==1.1.0
     #   botocore
 mysqlclient==2.2.8
     # via -r requirements.txt
-newrelic==12.1.0
+newrelic==13.0.0
     # via -r requirements.txt
-packaging==26.0
+packaging==26.2
     # via
     #   -r requirements.txt
     #   gunicorn
@@ -101,7 +101,7 @@ pynacl==1.6.2
     # via
     #   -r requirements.txt
     #   edx-django-utils
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -120,9 +120,9 @@ pyyaml==6.0.3
     # via
     #   -r requirements.txt
     #   edx-django-release-util
-requests==2.33.1
+requests==2.34.2
     # via -r requirements.txt
-s3transfer==0.16.0
+s3transfer==0.17.0
     # via
     #   -r requirements.txt
     #   boto3
@@ -135,11 +135,11 @@ sqlparse==0.5.5
     # via
     #   -r requirements.txt
     #   django
-stevedore==5.7.0
+stevedore==5.8.0
     # via
     #   -r requirements.txt
     #   edx-django-utils
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements.txt
     #   botocore


### PR DESCRIPTION
### Description

upgraded version of edx-django-utils
`edx-django-utils>=8.0.1`
to resolve incompatibility with newer New Relic Python agent versions. With out the change service fails to run successfully.

edx-django-utils 8.0.0 uses deprecated New Relic APIs that are no longer available in newer New Relic agent versions, causing xqueue failures. Version 8.0.1 is compatible with newer agents while remaining backward compatible.

Upgrade Python dependencies and pin edx-django-utils>=8.0.1 to address New Relic compatibility issues affecting xqueue.